### PR TITLE
docs(skill): add contextual-commit and recall skill definitions

### DIFF
--- a/.agents/skills/contextual-commit/SKILL.md
+++ b/.agents/skills/contextual-commit/SKILL.md
@@ -1,0 +1,192 @@
+---
+description: Write contextual commits that capture intent, decisions, and constraints alongside code changes. Use when committing code, finishing a task, or when the user asks to commit. Extends Conventional Commits with structured action lines in the commit body that preserve WHY code was written, not just WHAT changed.
+license: MIT
+metadata:
+    github-path: skills/contextual-commit
+    github-ref: refs/heads/main
+    github-repo: https://github.com/berserkdisruptors/contextual-commits
+    github-tree-sha: 86f1b04c940ef584ce7d7afa13133c6e49268c4d
+name: contextual-commit
+---
+# Contextual Commits
+
+You write commits that carry development reasoning in the body — the intent, decisions, constraints, and learnings that the diff alone cannot show.
+
+## The Problem You Solve
+
+Standard commits preserve WHAT changed. The diff shows that too. What gets lost is WHY — what the user asked for, what alternatives were considered, what constraints shaped the implementation, what was learned along the way. This context evaporates when the session ends. You prevent that.
+
+## Commit Format
+
+The subject line is a standard Conventional Commit. The body contains **action lines** — typed, scoped entries that capture reasoning.
+
+```
+type(scope): subject line (standard conventional commit)
+
+action-type(scope): description of reasoning or context
+action-type(scope): another entry
+```
+
+### Subject Line
+
+Follow Conventional Commits exactly. Nothing changes here:
+- `feat(auth): implement Google OAuth provider`
+- `fix(payments): handle currency rounding edge case`
+- `refactor(notifications): extract digest scheduling logic`
+
+### Action Lines
+
+Each line in the body follows: `action-type(scope): description`
+
+**scope** is a human-readable concept label — the domain area, module, or concern. Examples: `auth`, `payment-flow`, `oauth-library`, `session-store`, `api-contracts`. Use whatever is meaningful in this project's vocabulary. Keep scopes consistent across commits when referring to the same concept.
+
+## Action Types
+
+Use only the types that apply. Most commits need 1-3 action lines. Never pad with noise.
+
+### `intent(scope): ...`
+What the user wanted to achieve and why. Captures the human's voice, not your interpretation.
+
+- `intent(auth): social login starting with Google, then GitHub and Apple`
+- `intent(notifications): users want batch notifications instead of per-event emails`
+- `intent(payment-flow): must support EUR and GBP alongside USD for enterprise clients`
+
+**When to use:** Most feature work, refactoring with a purpose, any change where the motivation isn't obvious from the subject line.
+
+### `decision(scope): ...`
+What approach was chosen when alternatives existed. Brief reasoning.
+
+- `decision(oauth-library): passport.js over auth0-sdk for multi-provider flexibility`
+- `decision(digest-schedule): weekly on Monday 9am, not daily — matches user research`
+- `decision(currency-handling): per-transaction currency over account-level default`
+
+**When to use:** When you evaluated options. Skip for obvious choices with no real alternatives.
+
+### `rejected(scope): ...`
+What was considered and explicitly discarded, with the reason. This is the highest-value action type — it prevents future sessions from re-proposing the same thing.
+
+- `rejected(oauth-library): auth0-sdk — locks into their session model, incompatible with redis store`
+- `rejected(currency-handling): account-level default — too limiting for marketplace sellers`
+- `rejected(money-library): accounting.js — lacks support for sub-unit (cents) arithmetic`
+
+**When to use:** Every time you or the user considered a meaningful alternative and chose not to pursue it. Always include the reason.
+
+### `constraint(scope): ...`
+Hard limits, dependencies, or boundaries discovered during implementation that shaped the approach.
+
+- `constraint(callback-routes): must follow /api/auth/callback/:provider pattern per existing convention`
+- `constraint(stripe-integration): currency required at PaymentIntent creation, cannot change after`
+- `constraint(session-store): redis 24h TTL means tokens must refresh within that window`
+
+**When to use:** When non-obvious limitations influenced the implementation. Things the next person working here would need to know.
+
+### `learned(scope): ...`
+Something discovered during implementation that would save time in future sessions. API quirks, undocumented behavior, performance characteristics.
+
+- `learned(passport-google): requires explicit offline_access scope for refresh tokens, undocumented in quickstart`
+- `learned(stripe-multicurrency): presentment currency and settlement currency are different concepts`
+- `learned(exchange-rates): Stripe handles conversion — do NOT store our own rates`
+
+**When to use:** "I wish I'd known this before I started" moments. Library gotchas, API surprises, non-obvious behaviors.
+
+
+## Before You Write the Commit
+
+Determine the commit scope, then compose action lines:
+
+1. **Check for staged changes first** — run `git diff --cached --stat`.
+   - **If staged changes exist:** these are the commit scope. Do not consider unstaged or untracked files — the user has already expressed what belongs in this commit by staging it.
+   - **If nothing is staged:** consider all unstaged modifications and untracked files as candidates. Use session context and the diff to decide what to stage and commit.
+2. **Identify what you have session context for** — changes you produced, discussed, or observed reasoning for during this conversation.
+3. **Identify what you don't** — files or changes from a prior session, another agent, or manual edits outside this conversation.
+4. **Write action lines accordingly:**
+   - For changes you have context for: full action lines from session knowledge.
+   - For changes you don't: apply the "When You Lack Conversation Context" rules below — write only what the diff evidences.
+
+The commit message must account for ALL changes in the commit scope, not just the ones you worked on. Ignoring changes you didn't produce is worse than writing thin action lines for them.
+
+## Examples
+
+### Simple fix — no action lines needed
+
+```
+fix(button): correct alignment on mobile viewport
+```
+
+The conventional commit subject is sufficient. Don't add noise.
+
+### Moderate feature
+
+```
+feat(notifications): add email digest for weekly summaries
+
+intent(notifications): users want batch notifications instead of per-event emails
+decision(digest-schedule): weekly on Monday 9am — matches user research feedback
+constraint(email-provider): SendGrid batch API limited to 1000 recipients per call
+```
+
+### Complex architectural change
+
+```
+refactor(payments): migrate from single to multi-currency support
+
+intent(payments): enterprise customers need EUR and GBP alongside USD
+intent(payment-architecture): must be backward compatible, existing USD flows unchanged
+decision(currency-handling): per-transaction currency over account-level default
+rejected(currency-handling): account-level default too limiting for marketplace sellers
+rejected(money-library): accounting.js — lacks sub-unit arithmetic, using currency.js instead
+constraint(stripe-integration): Stripe requires currency at PaymentIntent creation, cannot change after
+constraint(database-migration): existing amount columns need companion currency columns, not replacement
+learned(stripe-multicurrency): presentment currency vs settlement currency are different Stripe concepts
+learned(exchange-rates): Stripe handles conversion, we should NOT store our own rates
+```
+
+### Mid-implementation pivot
+
+When intent changes during work, capture it on the commit where the pivot happens:
+
+```
+refactor(auth): switch from session-based to JWT tokens
+
+intent(auth): original session approach incompatible with redis cluster setup
+rejected(auth-sessions): redis cluster doesn't support session stickiness needed by passport sessions
+decision(auth-tokens): JWT with short expiry + refresh token pattern
+learned(redis-cluster): session affinity requires sticky sessions at load balancer level — too invasive
+```
+
+## When You Lack Conversation Context
+
+Sometimes staged changes include work you didn't produce in this session — prior session output, another agent's changes, pasted code, externally generated files, or manual edits. For any change where you lack the reasoning trail:
+
+**Only write action lines for what is clearly evidenced in the diff.** Do not speculate about intent or constraints you cannot observe.
+
+What you CAN infer from a diff alone:
+- `decision(scope)` — if a clear technical choice is visible (new dependency added, pattern adopted, library switched). Example: `decision(http-client): switched from axios to native fetch` is visible from the diff.
+
+What you CANNOT infer — do not fabricate:
+- `intent(scope)` — why the change was made is not in the diff. Don't restate what the diff shows.
+- `rejected(scope)` — what was NOT chosen is invisible in what WAS committed.
+- `constraint(scope)` — hard limits are almost never visible in code changes.
+- `learned(scope)` — learnings come from the process, not the output.
+
+**A clean conventional commit subject with no action lines is always better than fabricated context.**
+
+## Git Workflows
+
+Contextual commits work with every standard git workflow. No special handling needed.
+
+- **Regular merges:** Commit bodies preserved intact.
+- **Squash merges:** All commit bodies concatenated into the squash commit body. The result is a chronological trail of typed, scoped action lines — agents parse, filter, and group these without issue.
+- **Rebase and cherry-pick:** Commit bodies preserved.
+
+## Rules
+
+1. **The subject line is a Conventional Commit.** Never break existing conventions or tooling.
+2. **Action lines go in the body only.** Never in the subject line.
+3. **Only write action lines that carry signal.** If the diff already explains it, don't repeat it. If there was nothing to decide, reject, or discover, write no action lines.
+4. **Be concise but complete.** Each action line should be a single clear statement. No artificial length limits, but don't write essays either.
+5. **Use consistent scopes within a project.** If you called it `auth` in one commit, don't call it `authentication` in the next.
+6. **Capture the user's intent in their words.** For `intent` lines, reflect what the human asked for, not your implementation summary.
+7. **Always explain why for `rejected` lines.** A rejection without a reason is useless — the next agent will just re-propose it.
+8. **Don't invent action lines for trivial commits.** A typo fix, a dependency bump, a formatting change — the conventional commit subject is enough.
+9. **Don't fabricate context you don't have.** If you weren't part of the reasoning, don't pretend you were. See "When You Lack Conversation Context" above.

--- a/.agents/skills/recall/SKILL.md
+++ b/.agents/skills/recall/SKILL.md
@@ -1,0 +1,322 @@
+---
+description: Reconstruct and narrate the current development context from contextual commits. Run at session start, when resuming work, or when switching branches. Produces a brief, conversational summary of where things stand.
+license: MIT
+metadata:
+    github-path: skills/recall
+    github-ref: refs/heads/main
+    github-repo: https://github.com/berserkdisruptors/contextual-commits
+    github-tree-sha: 3cff78b3033b21917adbb5fd4dbbf5243368fedc
+name: recall
+---
+# Context Recall
+
+Reconstruct the development story from contextual commit history and present it as a natural briefing.
+
+## Argument Detection
+
+Check how `recall` was invoked:
+
+- **No arguments** — run the default mode (full branch/session briefing below).
+- **Bare word** (e.g. `recall auth`) — treat as a scope query. Jump to **Scope Query**.
+- **`word(word)` pattern** (e.g. `recall rejected(auth)`) — treat as an action+scope query. Jump to **Action+Scope Query**.
+
+---
+
+## Default Mode (no arguments)
+
+### Step 1: Detect Branch State
+
+Determine the working state:
+
+```bash
+CURRENT_BRANCH=$(git branch --show-current)
+DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@' || echo "main")
+
+# Find the actual parent branch, not just the repo default.
+# Try upstream tracking branch first (fast path).
+BASE_BRANCH=$(git rev-parse --abbrev-ref @{upstream} 2>/dev/null | sed 's|^origin/||')
+
+# If no upstream, find the nearest local branch by commit distance.
+if [ -z "$BASE_BRANCH" ]; then
+    BASE_BRANCH=$(git for-each-ref --format='%(refname:short)' refs/heads/ | while read branch; do
+        [ "$branch" = "$CURRENT_BRANCH" ] && continue
+        echo "$(git log --oneline "$branch..$CURRENT_BRANCH" 2>/dev/null | wc -l | tr -d ' ') $branch"
+    done | sort -n | head -1 | awk '{print $2}')
+fi
+
+# Final fallback to default branch.
+BASE_BRANCH=${BASE_BRANCH:-$DEFAULT_BRANCH}
+
+UNSTAGED=$(git diff --stat)
+STAGED=$(git diff --cached --stat)
+BRANCH_COMMITS=$(git log ${BASE_BRANCH}..HEAD --oneline 2>/dev/null | wc -l | tr -d ' ')
+```
+
+`DEFAULT_BRANCH` identifies the repository's primary branch (for scenario C/D detection). `BASE_BRANCH` identifies the closest ancestor branch — which may differ when feature branches are created from non-default branches (e.g., a feature branched from `develop`). All branch-relative queries use `BASE_BRANCH`.
+
+### Step 2: Gather Raw Material
+
+#### Scenario A — On a feature branch with commits
+
+This is the richest scenario. Gather:
+
+```bash
+# Contextual action lines from all branch commits
+git log ${BASE_BRANCH}..HEAD --format="%H%n%s%n%b%n---COMMIT_END---"
+
+# Unstaged changes (what's in progress right now)
+git diff --stat
+git diff  # read the actual diff for key changes
+
+# Staged changes
+git diff --cached --stat
+```
+
+#### Scenario B — On a feature branch with no commits yet
+
+```bash
+# Unstaged and staged changes only
+git diff --stat
+git diff --cached --stat
+
+# Last few commits on the parent branch for project context
+git log ${BASE_BRANCH} -10 --format="%H%n%s%n%b%n---COMMIT_END---"
+```
+
+#### Scenario C — On the default branch
+
+```bash
+# Recent commit history with contextual action lines
+git log -20 --format="%H%n%s%n%b%n---COMMIT_END---"
+```
+
+#### Scenario D — On the default branch with uncommitted changes
+
+```bash
+# Same as C plus uncommitted changes
+git log -20 --format="%H%n%s%n%b%n---COMMIT_END---"
+git diff --stat
+git diff --cached --stat
+```
+
+### Step 3: Extract Action Lines
+
+From the gathered commit bodies, extract lines matching:
+```
+^(intent|decision|rejected|constraint|learned)\(
+```
+
+Group them by commit (preserve chronological order) and by type (for synthesis).
+
+### Step 4: Synthesize Output
+
+**Signal density over narrative flow.** The output should be compact, scannable, and grounded entirely in what the commits and diffs show. Every line should be actionable information. No fluff, no conversational padding.
+
+#### For Scenario A (branch with commits):
+
+Output the branch state, then synthesize the contextual action lines into a dense briefing organized by what matters most for continuing work.
+
+Example output:
+```
+Branch: feat/google-oauth (4 commits ahead of main, unstaged changes in tests/)
+
+Active intent: Add Google as first social login provider. GitHub and Apple to follow.
+Approach: passport.js with /api/auth/callback/:provider convention.
+Rejected: auth0-sdk — session model incompatible with redis store.
+Constraints:
+  - Redis session TTL 24h, tokens must refresh within window
+  - Callback routes must follow existing :provider pattern
+Learned: passport-google needs explicit offline_access scope for refresh tokens.
+In progress: Integration tests for callback handler (unstaged).
+```
+
+When branched from a non-default branch:
+
+```
+Branch: feat/oauth-refresh (2 commits ahead of develop, no uncommitted changes)
+
+Active intent: Implement token refresh for OAuth providers.
+Constraint: Must stay compatible with the session store changes on develop.
+```
+
+Priority order:
+1. Active intent (what we're building and why)
+2. Current approach (decisions made)
+3. Rejected approaches (what NOT to re-explore — critical)
+4. Constraints (hard boundaries)
+5. Learnings (things that save time)
+6. In-progress work (unstaged/staged changes)
+
+If intent evolved during the branch (a pivot), show both the original and current intent to make the pivot visible.
+
+#### For Scenario B (branch with no commits):
+
+```
+Branch: feat/new-feature (0 commits ahead of develop)
+
+No contextual history on this branch yet.
+Staged: 2 files (src/auth/provider.ts, src/auth/types.ts)
+Unstaged: none
+
+Recent project activity (from develop):
+  - Auth: OAuth provider framework merged, Google working
+  - Payments: Multi-currency support shipped (EUR, GBP alongside USD)
+```
+
+#### For Scenario C (default branch, no changes):
+
+Synthesize recent merged work from the last 20 commits. Group by area of activity. Surface any active constraints or learnings that apply broadly.
+
+```
+Recent project activity:
+
+Auth: OAuth provider framework merged. Google working, GitHub and Apple planned.
+  - Rejected auth0-sdk (session model incompatible with redis store)
+  - Constraint: redis session TTL 24h, tokens must refresh within window
+
+Payments: Multi-currency support shipped (USD, EUR, GBP).
+  - Per-transaction currency, not account-level
+  - Constraint: Stripe locks currency at PaymentIntent creation
+  - Learned: presentment ≠ settlement currency in Stripe
+
+What do you want to work on?
+```
+
+#### For Scenario D (default branch with uncommitted changes):
+
+Same as Scenario C, with uncommitted changes noted at the top.
+
+#### When there are no contextual commits at all
+
+If the history contains conventional commits but no contextual action lines, **still produce useful output** from what exists:
+
+```
+Branch: main (no contextual commits found in recent history)
+
+Recent activity (from commit subjects):
+  - auth: 6 commits (OAuth implementation, middleware updates) — 2 days ago
+  - payments: 4 commits (currency handling, Stripe integration) — last week
+  - tests: 3 commits — last week
+  - config: 2 commits
+
+Most recent: feat(auth): implement Google OAuth provider
+
+No explicit intent, decisions, or constraints are captured in commit history.
+Using the contextual-commit skill on future commits will surface
+the reasoning behind changes that commit subjects alone cannot show.
+```
+
+This is honest about the signal quality while still providing useful orientation. The suggestion to adopt the skill is a natural next step, not a sales pitch.
+
+### Guidelines
+
+- **Dense over conversational.** Every line should carry information. No "Here's what's been happening" or "Let me tell you about."
+- **Grounded in data.** Only report what the action lines, commit subjects, and diffs actually show. Do not infer, speculate, or fill gaps.
+- **Surface rejections prominently.** Rejected approaches are the highest-value signal — they prevent wasted exploration.
+- **Group by scope when multiple scopes exist.** On the default branch with broad history, organize by domain area rather than chronologically.
+- **End with a prompt.** Close with "What do you want to work on?" or similar. Keep it short.
+- **Scale to the data.** If there are 2 contextual commits, the output is 3-4 lines. If there are 20, it's a few grouped paragraphs. Never pad thin data into a long output.
+
+---
+
+## Scope Query (`recall <scope>`)
+
+Targeted query across full repo history for a given scope. Prefix matching: `auth` matches `auth`, `auth-tokens`, `auth-library`, etc.
+
+### Step 1: Query
+
+```bash
+git log --all --grep="(${SCOPE}" --format="%H%n%s%n%b%n---COMMIT_END---"
+```
+
+### Step 2: Extract
+
+From the gathered commit bodies, extract lines matching:
+```bash
+grep -E "^(intent|decision|rejected|constraint|learned)\(${SCOPE}"
+```
+
+This captures all action lines whose scope starts with the query term.
+
+### Step 3: Output
+
+Group by action type, chronological within each group. Show which sub-scopes were found.
+
+Example (`recall auth`):
+```
+Scope: auth (also found: auth-tokens, auth-library)
+
+intent:
+  - social login starting with Google, then GitHub and Apple
+  - original session approach incompatible with redis cluster setup
+
+decision:
+  - passport.js over auth0-sdk for multi-provider flexibility
+  - JWT with short expiry + refresh token pattern
+
+rejected:
+  - auth0-sdk — locks into their session model, incompatible with redis store
+  - auth-sessions — redis cluster doesn't support session stickiness needed by passport sessions
+
+constraint:
+  - callback routes must follow /api/auth/callback/:provider pattern per existing convention
+  - redis 24h TTL means tokens must refresh within that window
+
+learned:
+  - passport-google needs explicit offline_access scope for refresh tokens
+  - redis-cluster session affinity requires sticky sessions at load balancer level — too invasive
+```
+
+If no matches are found, say so plainly and suggest checking the scope name.
+
+---
+
+## Action+Scope Query (`recall <action>(<scope>)`)
+
+Query a specific action type for a scope across full repo history.
+
+### Step 1: Query
+
+```bash
+git log --all --grep="${ACTION}(${SCOPE}" --format="%H%n%s%n%b%n---COMMIT_END---"
+```
+
+### Step 2: Extract
+
+```bash
+grep "^${ACTION}(${SCOPE}"
+```
+
+### Step 3: Output
+
+Flat chronological list with commit subject for provenance.
+
+Example (`recall rejected(auth)`):
+```
+rejected(auth) across history:
+
+  - auth0-sdk — locks into their session model, incompatible with redis store
+    from: feat(auth): implement Google OAuth provider
+
+  - auth-sessions — redis cluster doesn't support session stickiness needed by passport sessions
+    from: refactor(auth): switch from session-based to JWT tokens
+```
+
+If no matches are found, say so plainly.
+
+---
+
+## Proactive Usage
+
+Before making a significant decision in any scope area, check `rejected` and `constraint` lines for that scope first:
+
+```bash
+git log --all --grep="rejected(${SCOPE}" --format="%b" | grep "^rejected(${SCOPE}"
+git log --all --grep="constraint(${SCOPE}" --format="%b" | grep "^constraint(${SCOPE}"
+```
+
+If a previous commit recorded a `rejected` line for the approach you're about to propose, surface the rejection reason to the user **before** re-proposing it. The rejection may still stand, or circumstances may have changed — but the user should make that call with full context, not rediscover the same dead end.
+
+Similarly, check `constraint` lines before proposing an approach that might violate a known boundary.
+
+This check is lightweight and should become habitual for any scope you're actively working in.

--- a/.claude/skills/contextual-commit/SKILL.md
+++ b/.claude/skills/contextual-commit/SKILL.md
@@ -1,0 +1,192 @@
+---
+description: Write contextual commits that capture intent, decisions, and constraints alongside code changes. Use when committing code, finishing a task, or when the user asks to commit. Extends Conventional Commits with structured action lines in the commit body that preserve WHY code was written, not just WHAT changed.
+license: MIT
+metadata:
+    github-path: skills/contextual-commit
+    github-ref: refs/heads/main
+    github-repo: https://github.com/berserkdisruptors/contextual-commits
+    github-tree-sha: 86f1b04c940ef584ce7d7afa13133c6e49268c4d
+name: contextual-commit
+---
+# Contextual Commits
+
+You write commits that carry development reasoning in the body — the intent, decisions, constraints, and learnings that the diff alone cannot show.
+
+## The Problem You Solve
+
+Standard commits preserve WHAT changed. The diff shows that too. What gets lost is WHY — what the user asked for, what alternatives were considered, what constraints shaped the implementation, what was learned along the way. This context evaporates when the session ends. You prevent that.
+
+## Commit Format
+
+The subject line is a standard Conventional Commit. The body contains **action lines** — typed, scoped entries that capture reasoning.
+
+```
+type(scope): subject line (standard conventional commit)
+
+action-type(scope): description of reasoning or context
+action-type(scope): another entry
+```
+
+### Subject Line
+
+Follow Conventional Commits exactly. Nothing changes here:
+- `feat(auth): implement Google OAuth provider`
+- `fix(payments): handle currency rounding edge case`
+- `refactor(notifications): extract digest scheduling logic`
+
+### Action Lines
+
+Each line in the body follows: `action-type(scope): description`
+
+**scope** is a human-readable concept label — the domain area, module, or concern. Examples: `auth`, `payment-flow`, `oauth-library`, `session-store`, `api-contracts`. Use whatever is meaningful in this project's vocabulary. Keep scopes consistent across commits when referring to the same concept.
+
+## Action Types
+
+Use only the types that apply. Most commits need 1-3 action lines. Never pad with noise.
+
+### `intent(scope): ...`
+What the user wanted to achieve and why. Captures the human's voice, not your interpretation.
+
+- `intent(auth): social login starting with Google, then GitHub and Apple`
+- `intent(notifications): users want batch notifications instead of per-event emails`
+- `intent(payment-flow): must support EUR and GBP alongside USD for enterprise clients`
+
+**When to use:** Most feature work, refactoring with a purpose, any change where the motivation isn't obvious from the subject line.
+
+### `decision(scope): ...`
+What approach was chosen when alternatives existed. Brief reasoning.
+
+- `decision(oauth-library): passport.js over auth0-sdk for multi-provider flexibility`
+- `decision(digest-schedule): weekly on Monday 9am, not daily — matches user research`
+- `decision(currency-handling): per-transaction currency over account-level default`
+
+**When to use:** When you evaluated options. Skip for obvious choices with no real alternatives.
+
+### `rejected(scope): ...`
+What was considered and explicitly discarded, with the reason. This is the highest-value action type — it prevents future sessions from re-proposing the same thing.
+
+- `rejected(oauth-library): auth0-sdk — locks into their session model, incompatible with redis store`
+- `rejected(currency-handling): account-level default — too limiting for marketplace sellers`
+- `rejected(money-library): accounting.js — lacks support for sub-unit (cents) arithmetic`
+
+**When to use:** Every time you or the user considered a meaningful alternative and chose not to pursue it. Always include the reason.
+
+### `constraint(scope): ...`
+Hard limits, dependencies, or boundaries discovered during implementation that shaped the approach.
+
+- `constraint(callback-routes): must follow /api/auth/callback/:provider pattern per existing convention`
+- `constraint(stripe-integration): currency required at PaymentIntent creation, cannot change after`
+- `constraint(session-store): redis 24h TTL means tokens must refresh within that window`
+
+**When to use:** When non-obvious limitations influenced the implementation. Things the next person working here would need to know.
+
+### `learned(scope): ...`
+Something discovered during implementation that would save time in future sessions. API quirks, undocumented behavior, performance characteristics.
+
+- `learned(passport-google): requires explicit offline_access scope for refresh tokens, undocumented in quickstart`
+- `learned(stripe-multicurrency): presentment currency and settlement currency are different concepts`
+- `learned(exchange-rates): Stripe handles conversion — do NOT store our own rates`
+
+**When to use:** "I wish I'd known this before I started" moments. Library gotchas, API surprises, non-obvious behaviors.
+
+
+## Before You Write the Commit
+
+Determine the commit scope, then compose action lines:
+
+1. **Check for staged changes first** — run `git diff --cached --stat`.
+   - **If staged changes exist:** these are the commit scope. Do not consider unstaged or untracked files — the user has already expressed what belongs in this commit by staging it.
+   - **If nothing is staged:** consider all unstaged modifications and untracked files as candidates. Use session context and the diff to decide what to stage and commit.
+2. **Identify what you have session context for** — changes you produced, discussed, or observed reasoning for during this conversation.
+3. **Identify what you don't** — files or changes from a prior session, another agent, or manual edits outside this conversation.
+4. **Write action lines accordingly:**
+   - For changes you have context for: full action lines from session knowledge.
+   - For changes you don't: apply the "When You Lack Conversation Context" rules below — write only what the diff evidences.
+
+The commit message must account for ALL changes in the commit scope, not just the ones you worked on. Ignoring changes you didn't produce is worse than writing thin action lines for them.
+
+## Examples
+
+### Simple fix — no action lines needed
+
+```
+fix(button): correct alignment on mobile viewport
+```
+
+The conventional commit subject is sufficient. Don't add noise.
+
+### Moderate feature
+
+```
+feat(notifications): add email digest for weekly summaries
+
+intent(notifications): users want batch notifications instead of per-event emails
+decision(digest-schedule): weekly on Monday 9am — matches user research feedback
+constraint(email-provider): SendGrid batch API limited to 1000 recipients per call
+```
+
+### Complex architectural change
+
+```
+refactor(payments): migrate from single to multi-currency support
+
+intent(payments): enterprise customers need EUR and GBP alongside USD
+intent(payment-architecture): must be backward compatible, existing USD flows unchanged
+decision(currency-handling): per-transaction currency over account-level default
+rejected(currency-handling): account-level default too limiting for marketplace sellers
+rejected(money-library): accounting.js — lacks sub-unit arithmetic, using currency.js instead
+constraint(stripe-integration): Stripe requires currency at PaymentIntent creation, cannot change after
+constraint(database-migration): existing amount columns need companion currency columns, not replacement
+learned(stripe-multicurrency): presentment currency vs settlement currency are different Stripe concepts
+learned(exchange-rates): Stripe handles conversion, we should NOT store our own rates
+```
+
+### Mid-implementation pivot
+
+When intent changes during work, capture it on the commit where the pivot happens:
+
+```
+refactor(auth): switch from session-based to JWT tokens
+
+intent(auth): original session approach incompatible with redis cluster setup
+rejected(auth-sessions): redis cluster doesn't support session stickiness needed by passport sessions
+decision(auth-tokens): JWT with short expiry + refresh token pattern
+learned(redis-cluster): session affinity requires sticky sessions at load balancer level — too invasive
+```
+
+## When You Lack Conversation Context
+
+Sometimes staged changes include work you didn't produce in this session — prior session output, another agent's changes, pasted code, externally generated files, or manual edits. For any change where you lack the reasoning trail:
+
+**Only write action lines for what is clearly evidenced in the diff.** Do not speculate about intent or constraints you cannot observe.
+
+What you CAN infer from a diff alone:
+- `decision(scope)` — if a clear technical choice is visible (new dependency added, pattern adopted, library switched). Example: `decision(http-client): switched from axios to native fetch` is visible from the diff.
+
+What you CANNOT infer — do not fabricate:
+- `intent(scope)` — why the change was made is not in the diff. Don't restate what the diff shows.
+- `rejected(scope)` — what was NOT chosen is invisible in what WAS committed.
+- `constraint(scope)` — hard limits are almost never visible in code changes.
+- `learned(scope)` — learnings come from the process, not the output.
+
+**A clean conventional commit subject with no action lines is always better than fabricated context.**
+
+## Git Workflows
+
+Contextual commits work with every standard git workflow. No special handling needed.
+
+- **Regular merges:** Commit bodies preserved intact.
+- **Squash merges:** All commit bodies concatenated into the squash commit body. The result is a chronological trail of typed, scoped action lines — agents parse, filter, and group these without issue.
+- **Rebase and cherry-pick:** Commit bodies preserved.
+
+## Rules
+
+1. **The subject line is a Conventional Commit.** Never break existing conventions or tooling.
+2. **Action lines go in the body only.** Never in the subject line.
+3. **Only write action lines that carry signal.** If the diff already explains it, don't repeat it. If there was nothing to decide, reject, or discover, write no action lines.
+4. **Be concise but complete.** Each action line should be a single clear statement. No artificial length limits, but don't write essays either.
+5. **Use consistent scopes within a project.** If you called it `auth` in one commit, don't call it `authentication` in the next.
+6. **Capture the user's intent in their words.** For `intent` lines, reflect what the human asked for, not your implementation summary.
+7. **Always explain why for `rejected` lines.** A rejection without a reason is useless — the next agent will just re-propose it.
+8. **Don't invent action lines for trivial commits.** A typo fix, a dependency bump, a formatting change — the conventional commit subject is enough.
+9. **Don't fabricate context you don't have.** If you weren't part of the reasoning, don't pretend you were. See "When You Lack Conversation Context" above.

--- a/.claude/skills/recall/SKILL.md
+++ b/.claude/skills/recall/SKILL.md
@@ -1,0 +1,322 @@
+---
+description: Reconstruct and narrate the current development context from contextual commits. Run at session start, when resuming work, or when switching branches. Produces a brief, conversational summary of where things stand.
+license: MIT
+metadata:
+    github-path: skills/recall
+    github-ref: refs/heads/main
+    github-repo: https://github.com/berserkdisruptors/contextual-commits
+    github-tree-sha: 3cff78b3033b21917adbb5fd4dbbf5243368fedc
+name: recall
+---
+# Context Recall
+
+Reconstruct the development story from contextual commit history and present it as a natural briefing.
+
+## Argument Detection
+
+Check how `recall` was invoked:
+
+- **No arguments** — run the default mode (full branch/session briefing below).
+- **Bare word** (e.g. `recall auth`) — treat as a scope query. Jump to **Scope Query**.
+- **`word(word)` pattern** (e.g. `recall rejected(auth)`) — treat as an action+scope query. Jump to **Action+Scope Query**.
+
+---
+
+## Default Mode (no arguments)
+
+### Step 1: Detect Branch State
+
+Determine the working state:
+
+```bash
+CURRENT_BRANCH=$(git branch --show-current)
+DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@' || echo "main")
+
+# Find the actual parent branch, not just the repo default.
+# Try upstream tracking branch first (fast path).
+BASE_BRANCH=$(git rev-parse --abbrev-ref @{upstream} 2>/dev/null | sed 's|^origin/||')
+
+# If no upstream, find the nearest local branch by commit distance.
+if [ -z "$BASE_BRANCH" ]; then
+    BASE_BRANCH=$(git for-each-ref --format='%(refname:short)' refs/heads/ | while read branch; do
+        [ "$branch" = "$CURRENT_BRANCH" ] && continue
+        echo "$(git log --oneline "$branch..$CURRENT_BRANCH" 2>/dev/null | wc -l | tr -d ' ') $branch"
+    done | sort -n | head -1 | awk '{print $2}')
+fi
+
+# Final fallback to default branch.
+BASE_BRANCH=${BASE_BRANCH:-$DEFAULT_BRANCH}
+
+UNSTAGED=$(git diff --stat)
+STAGED=$(git diff --cached --stat)
+BRANCH_COMMITS=$(git log ${BASE_BRANCH}..HEAD --oneline 2>/dev/null | wc -l | tr -d ' ')
+```
+
+`DEFAULT_BRANCH` identifies the repository's primary branch (for scenario C/D detection). `BASE_BRANCH` identifies the closest ancestor branch — which may differ when feature branches are created from non-default branches (e.g., a feature branched from `develop`). All branch-relative queries use `BASE_BRANCH`.
+
+### Step 2: Gather Raw Material
+
+#### Scenario A — On a feature branch with commits
+
+This is the richest scenario. Gather:
+
+```bash
+# Contextual action lines from all branch commits
+git log ${BASE_BRANCH}..HEAD --format="%H%n%s%n%b%n---COMMIT_END---"
+
+# Unstaged changes (what's in progress right now)
+git diff --stat
+git diff  # read the actual diff for key changes
+
+# Staged changes
+git diff --cached --stat
+```
+
+#### Scenario B — On a feature branch with no commits yet
+
+```bash
+# Unstaged and staged changes only
+git diff --stat
+git diff --cached --stat
+
+# Last few commits on the parent branch for project context
+git log ${BASE_BRANCH} -10 --format="%H%n%s%n%b%n---COMMIT_END---"
+```
+
+#### Scenario C — On the default branch
+
+```bash
+# Recent commit history with contextual action lines
+git log -20 --format="%H%n%s%n%b%n---COMMIT_END---"
+```
+
+#### Scenario D — On the default branch with uncommitted changes
+
+```bash
+# Same as C plus uncommitted changes
+git log -20 --format="%H%n%s%n%b%n---COMMIT_END---"
+git diff --stat
+git diff --cached --stat
+```
+
+### Step 3: Extract Action Lines
+
+From the gathered commit bodies, extract lines matching:
+```
+^(intent|decision|rejected|constraint|learned)\(
+```
+
+Group them by commit (preserve chronological order) and by type (for synthesis).
+
+### Step 4: Synthesize Output
+
+**Signal density over narrative flow.** The output should be compact, scannable, and grounded entirely in what the commits and diffs show. Every line should be actionable information. No fluff, no conversational padding.
+
+#### For Scenario A (branch with commits):
+
+Output the branch state, then synthesize the contextual action lines into a dense briefing organized by what matters most for continuing work.
+
+Example output:
+```
+Branch: feat/google-oauth (4 commits ahead of main, unstaged changes in tests/)
+
+Active intent: Add Google as first social login provider. GitHub and Apple to follow.
+Approach: passport.js with /api/auth/callback/:provider convention.
+Rejected: auth0-sdk — session model incompatible with redis store.
+Constraints:
+  - Redis session TTL 24h, tokens must refresh within window
+  - Callback routes must follow existing :provider pattern
+Learned: passport-google needs explicit offline_access scope for refresh tokens.
+In progress: Integration tests for callback handler (unstaged).
+```
+
+When branched from a non-default branch:
+
+```
+Branch: feat/oauth-refresh (2 commits ahead of develop, no uncommitted changes)
+
+Active intent: Implement token refresh for OAuth providers.
+Constraint: Must stay compatible with the session store changes on develop.
+```
+
+Priority order:
+1. Active intent (what we're building and why)
+2. Current approach (decisions made)
+3. Rejected approaches (what NOT to re-explore — critical)
+4. Constraints (hard boundaries)
+5. Learnings (things that save time)
+6. In-progress work (unstaged/staged changes)
+
+If intent evolved during the branch (a pivot), show both the original and current intent to make the pivot visible.
+
+#### For Scenario B (branch with no commits):
+
+```
+Branch: feat/new-feature (0 commits ahead of develop)
+
+No contextual history on this branch yet.
+Staged: 2 files (src/auth/provider.ts, src/auth/types.ts)
+Unstaged: none
+
+Recent project activity (from develop):
+  - Auth: OAuth provider framework merged, Google working
+  - Payments: Multi-currency support shipped (EUR, GBP alongside USD)
+```
+
+#### For Scenario C (default branch, no changes):
+
+Synthesize recent merged work from the last 20 commits. Group by area of activity. Surface any active constraints or learnings that apply broadly.
+
+```
+Recent project activity:
+
+Auth: OAuth provider framework merged. Google working, GitHub and Apple planned.
+  - Rejected auth0-sdk (session model incompatible with redis store)
+  - Constraint: redis session TTL 24h, tokens must refresh within window
+
+Payments: Multi-currency support shipped (USD, EUR, GBP).
+  - Per-transaction currency, not account-level
+  - Constraint: Stripe locks currency at PaymentIntent creation
+  - Learned: presentment ≠ settlement currency in Stripe
+
+What do you want to work on?
+```
+
+#### For Scenario D (default branch with uncommitted changes):
+
+Same as Scenario C, with uncommitted changes noted at the top.
+
+#### When there are no contextual commits at all
+
+If the history contains conventional commits but no contextual action lines, **still produce useful output** from what exists:
+
+```
+Branch: main (no contextual commits found in recent history)
+
+Recent activity (from commit subjects):
+  - auth: 6 commits (OAuth implementation, middleware updates) — 2 days ago
+  - payments: 4 commits (currency handling, Stripe integration) — last week
+  - tests: 3 commits — last week
+  - config: 2 commits
+
+Most recent: feat(auth): implement Google OAuth provider
+
+No explicit intent, decisions, or constraints are captured in commit history.
+Using the contextual-commit skill on future commits will surface
+the reasoning behind changes that commit subjects alone cannot show.
+```
+
+This is honest about the signal quality while still providing useful orientation. The suggestion to adopt the skill is a natural next step, not a sales pitch.
+
+### Guidelines
+
+- **Dense over conversational.** Every line should carry information. No "Here's what's been happening" or "Let me tell you about."
+- **Grounded in data.** Only report what the action lines, commit subjects, and diffs actually show. Do not infer, speculate, or fill gaps.
+- **Surface rejections prominently.** Rejected approaches are the highest-value signal — they prevent wasted exploration.
+- **Group by scope when multiple scopes exist.** On the default branch with broad history, organize by domain area rather than chronologically.
+- **End with a prompt.** Close with "What do you want to work on?" or similar. Keep it short.
+- **Scale to the data.** If there are 2 contextual commits, the output is 3-4 lines. If there are 20, it's a few grouped paragraphs. Never pad thin data into a long output.
+
+---
+
+## Scope Query (`recall <scope>`)
+
+Targeted query across full repo history for a given scope. Prefix matching: `auth` matches `auth`, `auth-tokens`, `auth-library`, etc.
+
+### Step 1: Query
+
+```bash
+git log --all --grep="(${SCOPE}" --format="%H%n%s%n%b%n---COMMIT_END---"
+```
+
+### Step 2: Extract
+
+From the gathered commit bodies, extract lines matching:
+```bash
+grep -E "^(intent|decision|rejected|constraint|learned)\(${SCOPE}"
+```
+
+This captures all action lines whose scope starts with the query term.
+
+### Step 3: Output
+
+Group by action type, chronological within each group. Show which sub-scopes were found.
+
+Example (`recall auth`):
+```
+Scope: auth (also found: auth-tokens, auth-library)
+
+intent:
+  - social login starting with Google, then GitHub and Apple
+  - original session approach incompatible with redis cluster setup
+
+decision:
+  - passport.js over auth0-sdk for multi-provider flexibility
+  - JWT with short expiry + refresh token pattern
+
+rejected:
+  - auth0-sdk — locks into their session model, incompatible with redis store
+  - auth-sessions — redis cluster doesn't support session stickiness needed by passport sessions
+
+constraint:
+  - callback routes must follow /api/auth/callback/:provider pattern per existing convention
+  - redis 24h TTL means tokens must refresh within that window
+
+learned:
+  - passport-google needs explicit offline_access scope for refresh tokens
+  - redis-cluster session affinity requires sticky sessions at load balancer level — too invasive
+```
+
+If no matches are found, say so plainly and suggest checking the scope name.
+
+---
+
+## Action+Scope Query (`recall <action>(<scope>)`)
+
+Query a specific action type for a scope across full repo history.
+
+### Step 1: Query
+
+```bash
+git log --all --grep="${ACTION}(${SCOPE}" --format="%H%n%s%n%b%n---COMMIT_END---"
+```
+
+### Step 2: Extract
+
+```bash
+grep "^${ACTION}(${SCOPE}"
+```
+
+### Step 3: Output
+
+Flat chronological list with commit subject for provenance.
+
+Example (`recall rejected(auth)`):
+```
+rejected(auth) across history:
+
+  - auth0-sdk — locks into their session model, incompatible with redis store
+    from: feat(auth): implement Google OAuth provider
+
+  - auth-sessions — redis cluster doesn't support session stickiness needed by passport sessions
+    from: refactor(auth): switch from session-based to JWT tokens
+```
+
+If no matches are found, say so plainly.
+
+---
+
+## Proactive Usage
+
+Before making a significant decision in any scope area, check `rejected` and `constraint` lines for that scope first:
+
+```bash
+git log --all --grep="rejected(${SCOPE}" --format="%b" | grep "^rejected(${SCOPE}"
+git log --all --grep="constraint(${SCOPE}" --format="%b" | grep "^constraint(${SCOPE}"
+```
+
+If a previous commit recorded a `rejected` line for the approach you're about to propose, surface the rejection reason to the user **before** re-proposing it. The rejection may still stand, or circumstances may have changed — but the user should make that call with full context, not rediscover the same dead end.
+
+Similarly, check `constraint` lines before proposing an approach that might violate a known boundary.
+
+This check is lightweight and should become habitual for any scope you're actively working in.


### PR DESCRIPTION
## Summary
- Add `contextual-commit` skill for writing contextual commits with intent, decisions, and constraints
- Add `recall` skill for reconstructing development context from contextual commits
- Store skill definitions under both `.agents/` and `.claude/` for tool compatibility
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/suree33/gh-pr-todo/pull/61" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
