### PR TITLE
test(github): cover client.go to 100%

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -2,6 +2,7 @@
 package github
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -12,6 +13,8 @@ import (
 	"github.com/Suree33/gh-pr-todo/pkg/types"
 	"github.com/cli/go-gh/v2"
 )
+
+var ghExec func(args ...string) (bytes.Buffer, bytes.Buffer, error) = gh.Exec
 
 type PRFetcher interface {
 	FetchDiff(repo, pr string) (string, error)
@@ -53,7 +56,7 @@ func (c *Client) FetchDiff(repo, pr string) (string, error) {
 	if pr != "" {
 		args = append(args, pr)
 	}
-	stdOut, stdErr, err := gh.Exec(args...)
+	stdOut, stdErr, err := ghExec(args...)
 	if err != nil {
 		if msg := strings.TrimSpace(stdErr.String()); msg != "" {
 			return "", fmt.Errorf("%s", msg)
@@ -74,7 +77,7 @@ func (c *Client) FetchChangedFileContents(repo, pr, diffOutput string) (map[stri
 	if pr != "" {
 		args = append(args, pr)
 	}
-	stdOut, _, err := gh.Exec(args...)
+	stdOut, _, err := ghExec(args...)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +102,7 @@ func (c *Client) FetchChangedFileContents(repo, pr, diffOutput string) (map[stri
 			segments[i] = url.PathEscape(s)
 		}
 		apiPath := fmt.Sprintf("repos/%s/contents/%s?ref=%s", nwo, strings.Join(segments, "/"), sha)
-		out, _, err := gh.Exec("api", apiPath, "-H", "Accept: application/vnd.github.raw+json")
+		out, _, err := ghExec("api", apiPath, "-H", "Accept: application/vnd.github.raw+json")
 		if err != nil {
 			failedPaths = append(failedPaths, p)
 			continue

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -1,9 +1,23 @@
 package github
 
 import (
+	"bytes"
 	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"reflect"
+	"strings"
 	"testing"
+
+	"github.com/Suree33/gh-pr-todo/pkg/types"
 )
+
+func TestNewClient(t *testing.T) {
+	if NewClient() == nil {
+		t.Fatal("NewClient() = nil, expected non-nil")
+	}
+}
 
 func TestPRMetaHeadRepositoryNameWithOwner(t *testing.T) {
 	tests := []struct {
@@ -36,6 +50,24 @@ func TestPRMetaHeadRepositoryNameWithOwner(t *testing.T) {
 			}`,
 			expected: "Suree33/gh-pr-todo",
 		},
+		{
+			name: "returns empty when owner login missing",
+			payload: `{
+				"headRepository": {
+					"name": "gh-pr-todo"
+				}
+			}`,
+			expected: "",
+		},
+		{
+			name: "returns empty when name missing",
+			payload: `{
+				"headRepository": {
+					"owner": {"login": "Suree33"}
+				}
+			}`,
+			expected: "",
+		},
 	}
 
 	for _, tt := range tests {
@@ -50,4 +82,325 @@ func TestPRMetaHeadRepositoryNameWithOwner(t *testing.T) {
 			}
 		})
 	}
+}
+
+// withGhExec swaps the package-level ghExec for the duration of a test.
+// Tests that use this helper MUST NOT call t.Parallel(): the swap is a
+// global mutation and would race with concurrent subtests.
+func withGhExec(t *testing.T, fn func(args ...string) (bytes.Buffer, bytes.Buffer, error)) {
+	t.Helper()
+	original := ghExec
+	ghExec = fn
+	t.Cleanup(func() { ghExec = original })
+}
+
+// captureStderr redirects os.Stderr while fn runs and returns the captured
+// output. Like withGhExec it mutates a global, so callers must not use
+// t.Parallel().
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	original := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() error = %v", err)
+	}
+	os.Stderr = w
+	defer func() { os.Stderr = original }()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("w.Close() error = %v", err)
+	}
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("io.ReadAll() error = %v", err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatalf("r.Close() error = %v", err)
+	}
+	return string(out)
+}
+
+func TestFetchDiff(t *testing.T) {
+	tests := []struct {
+		name        string
+		repo        string
+		pr          string
+		stdout      string
+		stderr      string
+		execErr     error
+		wantOut     string
+		wantErr     string
+		wantWarning string
+		wantArgs    []string
+	}{
+		{
+			name:     "success without repo or pr",
+			stdout:   "diff --git a/x b/x\n",
+			wantOut:  "diff --git a/x b/x\n",
+			wantArgs: []string{"pr", "diff"},
+		},
+		{
+			name:     "success with repo and pr",
+			repo:     "owner/repo",
+			pr:       "42",
+			stdout:   "diff body",
+			wantOut:  "diff body",
+			wantArgs: []string{"pr", "diff", "-R", "owner/repo", "42"},
+		},
+		{
+			name:    "error with stderr message",
+			stderr:  "  bad credentials  ",
+			execErr: errors.New("exit 1"),
+			wantErr: "bad credentials",
+		},
+		{
+			name:    "error with empty stderr falls back to err",
+			execErr: errors.New("exit 1"),
+			wantErr: "exit 1",
+		},
+		{
+			name:        "stderr warning printed on success",
+			stdout:      "ok",
+			stderr:      "deprecation notice",
+			wantOut:     "ok",
+			wantWarning: "Warning: deprecation notice\n",
+			wantArgs:    []string{"pr", "diff"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotArgs []string
+			withGhExec(t, func(args ...string) (bytes.Buffer, bytes.Buffer, error) {
+				gotArgs = args
+				return *bytes.NewBufferString(tt.stdout), *bytes.NewBufferString(tt.stderr), tt.execErr
+			})
+
+			c := NewClient()
+			var got string
+			var gotErr error
+			stderrOut := captureStderr(t, func() {
+				got, gotErr = c.FetchDiff(tt.repo, tt.pr)
+			})
+
+			if tt.wantErr != "" {
+				if gotErr == nil {
+					t.Fatalf("FetchDiff() error = nil, expected %q", tt.wantErr)
+				}
+				if gotErr.Error() != tt.wantErr {
+					t.Fatalf("FetchDiff() error = %q, expected %q", gotErr.Error(), tt.wantErr)
+				}
+				return
+			}
+			if gotErr != nil {
+				t.Fatalf("FetchDiff() unexpected error = %v", gotErr)
+			}
+			if got != tt.wantOut {
+				t.Fatalf("FetchDiff() = %q, expected %q", got, tt.wantOut)
+			}
+			if tt.wantArgs != nil && !reflect.DeepEqual(gotArgs, tt.wantArgs) {
+				t.Fatalf("ghExec args = %v, expected %v", gotArgs, tt.wantArgs)
+			}
+			if tt.wantWarning != "" && !strings.Contains(stderrOut, tt.wantWarning) {
+				t.Fatalf("stderr = %q, expected to contain %q", stderrOut, tt.wantWarning)
+			}
+		})
+	}
+}
+
+const sampleDiff = `diff --git a/foo.go b/foo.go
+index 0000000..1111111 100644
+--- a/foo.go
++++ b/foo.go
+@@ -1,1 +1,2 @@
+ package foo
++// TODO: add bar
+`
+
+const twoFileDiff = `diff --git a/foo.go b/foo.go
+index 0000000..1111111 100644
+--- a/foo.go
++++ b/foo.go
+@@ -1,1 +1,2 @@
+ package foo
++// TODO: add bar
+diff --git a/bar.go b/bar.go
+index 0000000..2222222 100644
+--- a/bar.go
++++ b/bar.go
+@@ -1,1 +1,2 @@
+ package bar
++// TODO: add baz
+`
+
+func TestFetchChangedFileContents(t *testing.T) {
+	metaJSON := `{"headRefOid":"abc123","headRepository":{"nameWithOwner":"o/r"}}`
+
+	t.Run("returns pr view exec error", func(t *testing.T) {
+		withGhExec(t, func(args ...string) (bytes.Buffer, bytes.Buffer, error) {
+			return bytes.Buffer{}, bytes.Buffer{}, errors.New("boom")
+		})
+		c := NewClient()
+		got, err := c.FetchChangedFileContents("", "", sampleDiff)
+		if err == nil || err.Error() != "boom" {
+			t.Fatalf("expected boom error, got %v", err)
+		}
+		if got != nil {
+			t.Fatalf("expected nil files, got %v", got)
+		}
+	})
+
+	t.Run("invalid json", func(t *testing.T) {
+		withGhExec(t, func(args ...string) (bytes.Buffer, bytes.Buffer, error) {
+			return *bytes.NewBufferString("not-json"), bytes.Buffer{}, nil
+		})
+		c := NewClient()
+		_, err := c.FetchChangedFileContents("", "", sampleDiff)
+		if err == nil {
+			t.Fatal("expected json error, got nil")
+		}
+	})
+
+	t.Run("empty meta", func(t *testing.T) {
+		withGhExec(t, func(args ...string) (bytes.Buffer, bytes.Buffer, error) {
+			return *bytes.NewBufferString(`{}`), bytes.Buffer{}, nil
+		})
+		c := NewClient()
+		_, err := c.FetchChangedFileContents("", "", sampleDiff)
+		if err == nil || err.Error() != "could not determine PR head" {
+			t.Fatalf("expected PR head error, got %v", err)
+		}
+	})
+
+	t.Run("success with repo and pr", func(t *testing.T) {
+		var calls [][]string
+		withGhExec(t, func(args ...string) (bytes.Buffer, bytes.Buffer, error) {
+			calls = append(calls, args)
+			if args[0] == "pr" {
+				return *bytes.NewBufferString(metaJSON), bytes.Buffer{}, nil
+			}
+			return *bytes.NewBufferString("file contents"), bytes.Buffer{}, nil
+		})
+		c := NewClient()
+		got, err := c.FetchChangedFileContents("o/r", "1", sampleDiff)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if string(got["foo.go"]) != "file contents" {
+			t.Fatalf("got %v", got)
+		}
+		if len(calls) != 2 {
+			t.Fatalf("expected 2 ghExec calls, got %d: %v", len(calls), calls)
+		}
+		expectedFirst := []string{"pr", "view", "--json", "headRefOid,headRepository", "-R", "o/r", "1"}
+		if !reflect.DeepEqual(calls[0], expectedFirst) {
+			t.Fatalf("first call args = %v, expected %v", calls[0], expectedFirst)
+		}
+		expectedSecond := []string{"api", "repos/o/r/contents/foo.go?ref=abc123", "-H", "Accept: application/vnd.github.raw+json"}
+		if !reflect.DeepEqual(calls[1], expectedSecond) {
+			t.Fatalf("second call args = %v, expected %v", calls[1], expectedSecond)
+		}
+	})
+
+	t.Run("partial failure returns error and partial files", func(t *testing.T) {
+		withGhExec(t, func(args ...string) (bytes.Buffer, bytes.Buffer, error) {
+			if args[0] == "pr" {
+				return *bytes.NewBufferString(metaJSON), bytes.Buffer{}, nil
+			}
+			if strings.Contains(args[1], "/foo.go") {
+				return *bytes.NewBufferString("foo contents"), bytes.Buffer{}, nil
+			}
+			return bytes.Buffer{}, bytes.Buffer{}, errors.New("404")
+		})
+		c := NewClient()
+		got, err := c.FetchChangedFileContents("", "", twoFileDiff)
+		if err == nil || !strings.Contains(err.Error(), "failed to fetch 1") {
+			t.Fatalf("expected failed-to-fetch error, got %v", err)
+		}
+		if string(got["foo.go"]) != "foo contents" {
+			t.Fatalf("expected foo.go to be present with successful contents, got map=%v", got)
+		}
+		if _, ok := got["bar.go"]; ok {
+			t.Fatalf("expected bar.go to be absent (fetch failed), got map=%v", got)
+		}
+	})
+}
+
+type stubFetcher struct {
+	diff      string
+	diffErr   error
+	files     map[string][]byte
+	filesErr  error
+	gotRepoFD string
+	gotPRFD   string
+	gotRepoFC string
+	gotPRFC   string
+	gotDiffFC string
+}
+
+func (s *stubFetcher) FetchDiff(repo, pr string) (string, error) {
+	s.gotRepoFD, s.gotPRFD = repo, pr
+	return s.diff, s.diffErr
+}
+
+func (s *stubFetcher) FetchChangedFileContents(repo, pr, diff string) (map[string][]byte, error) {
+	s.gotRepoFC, s.gotPRFC, s.gotDiffFC = repo, pr, diff
+	return s.files, s.filesErr
+}
+
+func TestCollectTODOs(t *testing.T) {
+	t.Run("FetchDiff error returned", func(t *testing.T) {
+		s := &stubFetcher{diffErr: errors.New("diff failed")}
+		todos, err := CollectTODOs(s, "o/r", "1")
+		if err == nil || err.Error() != "diff failed" {
+			t.Fatalf("expected diff failed error, got %v", err)
+		}
+		if todos != nil {
+			t.Fatalf("expected nil todos, got %v", todos)
+		}
+	})
+
+	t.Run("FetchChangedFileContents error logs warning and continues", func(t *testing.T) {
+		s := &stubFetcher{
+			diff:     sampleDiff,
+			files:    nil,
+			filesErr: errors.New("contents failed"),
+		}
+		var todos []types.TODO
+		var err error
+		stderrOut := captureStderr(t, func() {
+			todos, err = CollectTODOs(s, "o/r", "2")
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(stderrOut, "Warning: could not fetch changed file contents") {
+			t.Fatalf("expected warning on stderr, got %q", stderrOut)
+		}
+		if todos == nil {
+			t.Fatal("expected todos slice (possibly empty), got nil")
+		}
+	})
+
+	t.Run("success with files", func(t *testing.T) {
+		s := &stubFetcher{
+			diff:  sampleDiff,
+			files: map[string][]byte{"foo.go": []byte("package foo\n// TODO: add bar\n")},
+		}
+		todos, err := CollectTODOs(s, "o/r", "3")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if todos == nil {
+			t.Fatal("expected todos slice, got nil")
+		}
+		if s.gotRepoFD != "o/r" || s.gotPRFD != "3" {
+			t.Fatalf("FetchDiff received repo=%q pr=%q", s.gotRepoFD, s.gotPRFD)
+		}
+		if s.gotDiffFC != sampleDiff {
+			t.Fatalf("FetchChangedFileContents received diff %q", s.gotDiffFC)
+		}
+	})
 }


### PR DESCRIPTION
## Summary

Brings test coverage of `internal/github/client.go` from **6.8% to 100.0%**.

## Changes

### `internal/github/client.go`
- Introduced a package-level `ghExec` variable so unit tests can stub the `gh` CLI without shelling out:
  ```go
  var ghExec func(args ...string) (bytes.Buffer, bytes.Buffer, error) = gh.Exec
  ```
  Direct assignment (rather than a closure literal) avoids leaving an extra uncovered wrapper statement, allowing true 100% statement coverage.

### `internal/github/client_test.go`
Added tests for:
- `NewClient`
- `headRepositoryNameWithOwner`: `nameWithOwner` path / `owner.login + name` fallback / empty cases for missing fields
- `FetchDiff`: no args / repo + pr / error with stderr message / error without stderr / warning passthrough on success
- `FetchChangedFileContents`: `pr view` exec error / invalid JSON / empty meta / success (with arg-construction assertions) / partial failure (foo.go succeeds, bar.go fails)
- `CollectTODOs`: `FetchDiff` error / `FetchChangedFileContents` error logs warning and continues / success

Helpers `withGhExec` and `captureStderr` mutate package globals (`ghExec`, `os.Stderr`); their doc comments note that callers must not use `t.Parallel()`.

## Coverage

```
github.com/Suree33/gh-pr-todo/internal/github/client.go:26:	NewClient			100.0%
github.com/Suree33/gh-pr-todo/internal/github/client.go:41:	headRepositoryNameWithOwner	100.0%
github.com/Suree33/gh-pr-todo/internal/github/client.go:51:	FetchDiff			100.0%
github.com/Suree33/gh-pr-todo/internal/github/client.go:72:	FetchChangedFileContents	100.0%
github.com/Suree33/gh-pr-todo/internal/github/client.go:119:	CollectTODOs			100.0%
total:								(statements)			100.0%
```

## Verification

- `go build ./...` ✅
- `go test ./...` ✅
- `golangci-lint run` ✅ (0 issues)
- Two rounds of oracle review; all feedback addressed

🤖 Generated with [Amp](https://ampcode.com/)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/suree33/gh-pr-todo/pull/62" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
