### PR TITLE
test(output): add printer tests and fix output bug

### DIFF
--- a/internal/output/printer.go
+++ b/internal/output/printer.go
@@ -39,7 +39,9 @@ func PrintFileNames(todos []types.TODO) {
 	for _, todo := range todos {
 		files[todo.Filename] = struct{}{}
 	}
-	for file := range files {
+	fileNames := slices.Collect(maps.Keys(files))
+	slices.Sort(fileNames)
+	for _, file := range fileNames {
 		fmt.Fprintln(color.Output, file)
 	}
 }
@@ -64,13 +66,15 @@ func printGroupedByFile(todos []types.TODO) {
 			maxLineNumberLen = n
 		}
 	}
-	for filename, todos := range files {
+	fileNames := slices.Collect(maps.Keys(files))
+	slices.Sort(fileNames)
+	for _, filename := range fileNames {
 		fmt.Fprintf(color.Output, "* %s\n", Blue(filename))
-		for _, todo := range todos {
+		for _, todo := range files[filename] {
 			lineStr := strconv.Itoa(todo.Line)
 			fmt.Fprintf(color.Output, "  %s%s: %s\n", strings.Repeat(" ", maxLineNumberLen-len(lineStr)), Green(lineStr), todo.Comment)
 		}
-		fmt.Println()
+		fmt.Fprintln(color.Output)
 	}
 }
 

--- a/internal/output/printer_test.go
+++ b/internal/output/printer_test.go
@@ -1,0 +1,131 @@
+package output
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/Suree33/gh-pr-todo/pkg/types"
+	"github.com/fatih/color"
+)
+
+func captureOutput(t *testing.T, fn func()) string {
+	t.Helper()
+	prevOutput := color.Output
+	prevNoColor := color.NoColor
+	buf := &bytes.Buffer{}
+	color.Output = buf
+	color.NoColor = true
+	t.Cleanup(func() {
+		color.Output = prevOutput
+		color.NoColor = prevNoColor
+	})
+	fn()
+	return buf.String()
+}
+
+func TestPrintTODOs(t *testing.T) {
+	todos := []types.TODO{
+		{Filename: "a.go", Line: 5, Comment: "// TODO: a", Type: "TODO"},
+		{Filename: "a.go", Line: 100, Comment: "// HACK: long line", Type: "HACK"},
+		{Filename: "b.go", Line: 20, Comment: "// FIXME: b", Type: "FIXME"},
+	}
+
+	tests := []struct {
+		name    string
+		groupBy types.GroupBy
+		want    string
+	}{
+		{
+			name:    "GroupByNone",
+			groupBy: types.GroupByNone,
+			want: "* a.go:5\n  // TODO: a\n\n" +
+				"* a.go:100\n  // HACK: long line\n\n" +
+				"* b.go:20\n  // FIXME: b\n\n",
+		},
+		{
+			name:    "GroupByFile",
+			groupBy: types.GroupByFile,
+			want: "* a.go\n" +
+				"    5: // TODO: a\n" +
+				"  100: // HACK: long line\n" +
+				"\n" +
+				"* b.go\n" +
+				"   20: // FIXME: b\n" +
+				"\n",
+		},
+		{
+			name:    "GroupByType",
+			groupBy: types.GroupByType,
+			want: "[FIXME]\n" +
+				"* b.go:20\n  // FIXME: b\n\n" +
+				"[HACK]\n" +
+				"* a.go:100\n  // HACK: long line\n\n" +
+				"[TODO]\n" +
+				"* a.go:5\n  // TODO: a\n\n",
+		},
+		{
+			name:    "unknown groupBy is a no-op",
+			groupBy: types.GroupBy("bogus"),
+			want:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := captureOutput(t, func() { PrintTODOs(todos, tt.groupBy) })
+			if got != tt.want {
+				t.Errorf("output mismatch\n--- want ---\n%s\n--- got ---\n%s", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestPrintFileNames(t *testing.T) {
+	tests := []struct {
+		name  string
+		todos []types.TODO
+		want  string
+	}{
+		{
+			name:  "empty",
+			todos: nil,
+			want:  "",
+		},
+		{
+			name: "deduplicated and sorted",
+			todos: []types.TODO{
+				{Filename: "b.go", Line: 1},
+				{Filename: "a.go", Line: 2},
+				{Filename: "b.go", Line: 3},
+			},
+			want: "a.go\nb.go\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := captureOutput(t, func() { PrintFileNames(tt.todos) })
+			if got != tt.want {
+				t.Errorf("expected %q, got %q", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestPrintCount(t *testing.T) {
+	tests := []struct {
+		name  string
+		todos []types.TODO
+		want  string
+	}{
+		{"zero", nil, "0\n"},
+		{"some", []types.TODO{{}, {}, {}}, "3\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := captureOutput(t, func() { PrintCount(tt.todos) })
+			if got != tt.want {
+				t.Errorf("expected %q, got %q", tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds tests for `internal/output/printer.go` reaching 100% statement coverage, and fixes two issues uncovered during review.

## Changes

### Bug fix
- `printGroupedByFile` used `fmt.Println` for the trailing blank line between file groups, writing it to real stdout instead of `color.Output`. The blank line now goes through the configured writer.

### Deterministic output
- `PrintFileNames` and `printGroupedByFile` previously iterated over maps, so CLI output order was random across runs. Filename keys are now collected and sorted before printing, giving stable output and exact-match testability.

### Tests
- New `internal/output/printer_test.go` covers `PrintTODOs` (all `GroupBy` branches plus the unknown/no-op case), `PrintFileNames` (empty + dedup/sort), and `PrintCount`.
- A small `captureOutput` helper swaps `color.Output` to a buffer and sets `color.NoColor=true` so assertions can compare plain text against full expected output.

## Verification

```
go test -v -cover ./internal/output/...
# coverage: 100.0% of statements
golangci-lint run ./internal/output/...
# 0 issues.
```

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/suree33/gh-pr-todo/pull/63" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

BEGIN_COMMIT_OVERRIDE
test(output): add printer tests and fix output bug
END_COMMIT_OVERRIDE
