### PR TITLE
test(types): cover GroupBy to 100% package coverage

### DIFF
--- a/pkg/types/groupby_test.go
+++ b/pkg/types/groupby_test.go
@@ -1,0 +1,59 @@
+package types
+
+import "testing"
+
+func TestGroupBy_Set(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    GroupBy
+		wantErr bool
+	}{
+		{name: "file lowercase", input: "file", want: GroupByFile},
+		{name: "type lowercase", input: "type", want: GroupByType},
+		{name: "file mixed case", input: "FILE", want: GroupByFile},
+		{name: "type mixed case", input: "Type", want: GroupByType},
+		{name: "invalid", input: "bogus", wantErr: true},
+		{name: "empty", input: "", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var g GroupBy
+			err := g.Set(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Set(%q) error = %v, wantErr = %v", tt.input, err, tt.wantErr)
+			}
+			if !tt.wantErr && g != tt.want {
+				t.Errorf("Set(%q) = %q, want %q", tt.input, g, tt.want)
+			}
+		})
+	}
+}
+
+func TestGroupBy_String(t *testing.T) {
+	tests := []struct {
+		name string
+		g    GroupBy
+		want string
+	}{
+		{name: "none", g: GroupByNone, want: ""},
+		{name: "file", g: GroupByFile, want: "file"},
+		{name: "type", g: GroupByType, want: "type"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.g.String(); got != tt.want {
+				t.Errorf("String() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGroupBy_Type(t *testing.T) {
+	var g GroupBy
+	if got := g.Type(); got != "group-by" {
+		t.Errorf("Type() = %q, want %q", got, "group-by")
+	}
+}

--- a/pkg/types/groupby_test.go
+++ b/pkg/types/groupby_test.go
@@ -1,10 +1,14 @@
 package types
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestGroupBy_Set(t *testing.T) {
 	tests := []struct {
 		name    string
+		initial GroupBy
 		input   string
 		want    GroupBy
 		wantErr bool
@@ -15,16 +19,29 @@ func TestGroupBy_Set(t *testing.T) {
 		{name: "type mixed case", input: "Type", want: GroupByType},
 		{name: "invalid", input: "bogus", wantErr: true},
 		{name: "empty", input: "", wantErr: true},
+		{name: "invalid does not mutate existing value", initial: GroupByFile, input: "bogus", want: GroupByFile, wantErr: true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var g GroupBy
+			g := tt.initial
 			err := g.Set(tt.input)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("Set(%q) error = %v, wantErr = %v", tt.input, err, tt.wantErr)
 			}
-			if !tt.wantErr && g != tt.want {
+			if tt.wantErr {
+				msg := err.Error()
+				for _, want := range []string{tt.input, "--group-by", `"file"`, `"type"`} {
+					if !strings.Contains(msg, want) {
+						t.Errorf("Set(%q) error %q does not contain %q", tt.input, msg, want)
+					}
+				}
+				if g != tt.want {
+					t.Errorf("Set(%q) mutated value to %q, want %q", tt.input, g, tt.want)
+				}
+				return
+			}
+			if g != tt.want {
 				t.Errorf("Set(%q) = %q, want %q", tt.input, g, tt.want)
 			}
 		})

--- a/pkg/types/groupby_test.go
+++ b/pkg/types/groupby_test.go
@@ -7,19 +7,20 @@ import (
 
 func TestGroupBy_Set(t *testing.T) {
 	tests := []struct {
-		name    string
-		initial GroupBy
-		input   string
-		want    GroupBy
-		wantErr bool
+		name         string
+		initial      GroupBy
+		input        string
+		want         GroupBy
+		wantErr      bool
+		wantErrParts []string
 	}{
 		{name: "file lowercase", input: "file", want: GroupByFile},
 		{name: "type lowercase", input: "type", want: GroupByType},
 		{name: "file mixed case", input: "FILE", want: GroupByFile},
 		{name: "type mixed case", input: "Type", want: GroupByType},
-		{name: "invalid", input: "bogus", wantErr: true},
-		{name: "empty", input: "", wantErr: true},
-		{name: "invalid does not mutate existing value", initial: GroupByFile, input: "bogus", want: GroupByFile, wantErr: true},
+		{name: "invalid", input: "bogus", wantErr: true, wantErrParts: []string{"bogus", "--group-by", `"file"`, `"type"`}},
+		{name: "empty", input: "", wantErr: true, wantErrParts: []string{`""`, "--group-by", `"file"`, `"type"`}},
+		{name: "invalid does not mutate existing value", initial: GroupByFile, input: "bogus", want: GroupByFile, wantErr: true, wantErrParts: []string{"bogus", "--group-by", `"file"`, `"type"`}},
 	}
 
 	for _, tt := range tests {
@@ -31,7 +32,7 @@ func TestGroupBy_Set(t *testing.T) {
 			}
 			if tt.wantErr {
 				msg := err.Error()
-				for _, want := range []string{tt.input, "--group-by", `"file"`, `"type"`} {
+				for _, want := range tt.wantErrParts {
 					if !strings.Contains(msg, want) {
 						t.Errorf("Set(%q) error %q does not contain %q", tt.input, msg, want)
 					}


### PR DESCRIPTION
## Summary

Brings `pkg/types` to 100% statement coverage by adding tests for the `GroupBy` flag value methods (`Set`, `String`, `Type`).

## Changes

- Add table-driven tests for `GroupBy.Set`:
  - valid lower/mixed-case values (`file`, `FILE`, `type`, `Type`)
  - invalid input and empty input
  - asserts error message includes the bad input, `--group-by`, and the allowed values `"file"`, `"type"`
  - asserts `Set` does not mutate an already-set value when input is invalid
- Add table-driven tests for `GroupBy.String` covering `GroupByNone`, `GroupByFile`, `GroupByType`
- Add test for `GroupBy.Type` returning `"group-by"`

`TODO` is a plain data struct with no methods, so no test file is needed for it; package coverage is 100% without one.

## Verification

```
$ go test -v -cover ./pkg/types/
...
PASS
coverage: 100.0% of statements
ok  	github.com/Suree33/gh-pr-todo/pkg/types	0.003s	coverage: 100.0% of statements
```

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/suree33/gh-pr-todo/pull/64" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
