### PR TITLE
test(main): add tests for run* helpers and printUsage

### DIFF
--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -206,6 +206,9 @@ func TestFetchDiff(t *testing.T) {
 			if tt.wantWarning != "" && !strings.Contains(stderrOut, tt.wantWarning) {
 				t.Fatalf("stderr = %q, expected to contain %q", stderrOut, tt.wantWarning)
 			}
+			if tt.wantWarning == "" && stderrOut != "" {
+				t.Fatalf("stderr = %q, expected empty", stderrOut)
+			}
 		})
 	}
 }
@@ -389,9 +392,18 @@ func TestCollectTODOs(t *testing.T) {
 			diff:  sampleDiff,
 			files: map[string][]byte{"foo.go": []byte("package foo\n// TODO: add bar\n")},
 		}
-		todos, err := CollectTODOs(s, "o/r", "3")
+		var (
+			todos []types.TODO
+			err   error
+		)
+		stderrOut := captureStderr(t, func() {
+			todos, err = CollectTODOs(s, "o/r", "3")
+		})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
+		}
+		if stderrOut != "" {
+			t.Fatalf("stderr = %q, expected empty", stderrOut)
 		}
 		if todos == nil {
 			t.Fatal("expected todos slice, got nil")

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -335,15 +335,16 @@ func TestFetchChangedFileContents(t *testing.T) {
 }
 
 type stubFetcher struct {
-	diff      string
-	diffErr   error
-	files     map[string][]byte
-	filesErr  error
-	gotRepoFD string
-	gotPRFD   string
-	gotRepoFC string
-	gotPRFC   string
-	gotDiffFC string
+	diff          string
+	diffErr       error
+	files         map[string][]byte
+	filesErr      error
+	gotRepoFD     string
+	gotPRFD       string
+	gotRepoFC     string
+	gotPRFC       string
+	gotDiffFC     string
+	fetchFCCalled bool
 }
 
 func (s *stubFetcher) FetchDiff(repo, pr string) (string, error) {
@@ -352,6 +353,7 @@ func (s *stubFetcher) FetchDiff(repo, pr string) (string, error) {
 }
 
 func (s *stubFetcher) FetchChangedFileContents(repo, pr, diff string) (map[string][]byte, error) {
+	s.fetchFCCalled = true
 	s.gotRepoFC, s.gotPRFC, s.gotDiffFC = repo, pr, diff
 	return s.files, s.filesErr
 }
@@ -359,12 +361,24 @@ func (s *stubFetcher) FetchChangedFileContents(repo, pr, diff string) (map[strin
 func TestCollectTODOs(t *testing.T) {
 	t.Run("FetchDiff error returned", func(t *testing.T) {
 		s := &stubFetcher{diffErr: errors.New("diff failed")}
-		todos, err := CollectTODOs(s, "o/r", "1")
+		var (
+			todos []types.TODO
+			err   error
+		)
+		stderrOut := captureStderr(t, func() {
+			todos, err = CollectTODOs(s, "o/r", "1")
+		})
 		if err == nil || err.Error() != "diff failed" {
 			t.Fatalf("expected diff failed error, got %v", err)
 		}
 		if todos != nil {
 			t.Fatalf("expected nil todos, got %v", todos)
+		}
+		if stderrOut != "" {
+			t.Fatalf("stderr = %q, expected empty", stderrOut)
+		}
+		if s.fetchFCCalled {
+			t.Fatal("FetchChangedFileContents should not be called when FetchDiff fails")
 		}
 	})
 

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -192,6 +192,9 @@ func TestFetchDiff(t *testing.T) {
 				if gotErr.Error() != tt.wantErr {
 					t.Fatalf("FetchDiff() error = %q, expected %q", gotErr.Error(), tt.wantErr)
 				}
+				if stderrOut != "" {
+					t.Fatalf("stderr = %q, expected empty on error path", stderrOut)
+				}
 				return
 			}
 			if gotErr != nil {
@@ -365,6 +368,13 @@ func TestCollectTODOs(t *testing.T) {
 		}
 	})
 
+	expectedTODO := types.TODO{
+		Filename: "foo.go",
+		Line:     2,
+		Comment:  "// TODO: add bar",
+		Type:     "TODO",
+	}
+
 	t.Run("FetchChangedFileContents error logs warning and continues", func(t *testing.T) {
 		s := &stubFetcher{
 			diff:     sampleDiff,
@@ -382,8 +392,8 @@ func TestCollectTODOs(t *testing.T) {
 		if !strings.Contains(stderrOut, "Warning: could not fetch changed file contents") {
 			t.Fatalf("expected warning on stderr, got %q", stderrOut)
 		}
-		if todos == nil {
-			t.Fatal("expected todos slice (possibly empty), got nil")
+		if !reflect.DeepEqual(todos, []types.TODO{expectedTODO}) {
+			t.Fatalf("todos = %#v, expected %#v", todos, []types.TODO{expectedTODO})
 		}
 	})
 
@@ -405,11 +415,14 @@ func TestCollectTODOs(t *testing.T) {
 		if stderrOut != "" {
 			t.Fatalf("stderr = %q, expected empty", stderrOut)
 		}
-		if todos == nil {
-			t.Fatal("expected todos slice, got nil")
+		if !reflect.DeepEqual(todos, []types.TODO{expectedTODO}) {
+			t.Fatalf("todos = %#v, expected %#v", todos, []types.TODO{expectedTODO})
 		}
 		if s.gotRepoFD != "o/r" || s.gotPRFD != "3" {
 			t.Fatalf("FetchDiff received repo=%q pr=%q", s.gotRepoFD, s.gotPRFD)
+		}
+		if s.gotRepoFC != "o/r" || s.gotPRFC != "3" {
+			t.Fatalf("FetchChangedFileContents received repo=%q pr=%q", s.gotRepoFC, s.gotPRFC)
 		}
 		if s.gotDiffFC != sampleDiff {
 			t.Fatalf("FetchChangedFileContents received diff %q", s.gotDiffFC)

--- a/main.go
+++ b/main.go
@@ -13,8 +13,6 @@ import (
 	"github.com/spf13/pflag"
 )
 
-var newFetcher func() ghclient.PRFetcher = func() ghclient.PRFetcher { return ghclient.NewClient() }
-
 func main() {
 	var (
 		repo     string
@@ -54,14 +52,15 @@ func main() {
 		os.Exit(1)
 	}
 
+	fetcher := ghclient.NewClient()
 	var err error
 	switch {
 	case nameOnly:
-		err = runNameOnly(repo, pr)
+		err = runNameOnly(fetcher, repo, pr)
 	case isCount:
-		err = runCount(repo, pr)
+		err = runCount(fetcher, repo, pr)
 	default:
-		err = runMain(repo, pr, groupBy)
+		err = runMain(fetcher, repo, pr, groupBy)
 	}
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -91,16 +90,16 @@ func printUsage() {
 			fmt.Fprintf(color.Output, "      --%-*s %s\n", maxLen+2, f.Name, f.Usage)
 		}
 	})
-	fmt.Println()
+	fmt.Fprintln(color.Output)
 }
 
-func runMain(repo, pr string, groupBy types.GroupBy) error {
+func runMain(fetcher ghclient.PRFetcher, repo, pr string, groupBy types.GroupBy) error {
 	sp := spinner.New(spinner.CharSets[14], 40*time.Millisecond)
 	fetchingMsg := " Fetching PR diff..."
 	sp.Suffix = fetchingMsg
 	sp.Start()
 
-	todos, err := ghclient.CollectTODOs(newFetcher(), repo, pr)
+	todos, err := ghclient.CollectTODOs(fetcher, repo, pr)
 	sp.Stop()
 
 	if err != nil {
@@ -119,8 +118,8 @@ func runMain(repo, pr string, groupBy types.GroupBy) error {
 	return nil
 }
 
-func runCount(repo, pr string) error {
-	todos, err := ghclient.CollectTODOs(newFetcher(), repo, pr)
+func runCount(fetcher ghclient.PRFetcher, repo, pr string) error {
+	todos, err := ghclient.CollectTODOs(fetcher, repo, pr)
 	if err != nil {
 		return err
 	}
@@ -128,8 +127,8 @@ func runCount(repo, pr string) error {
 	return nil
 }
 
-func runNameOnly(repo, pr string) error {
-	todos, err := ghclient.CollectTODOs(newFetcher(), repo, pr)
+func runNameOnly(fetcher ghclient.PRFetcher, repo, pr string) error {
+	todos, err := ghclient.CollectTODOs(fetcher, repo, pr)
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -13,6 +13,8 @@ import (
 	"github.com/spf13/pflag"
 )
 
+var newFetcher func() ghclient.PRFetcher = func() ghclient.PRFetcher { return ghclient.NewClient() }
+
 func main() {
 	var (
 		repo     string
@@ -98,7 +100,7 @@ func runMain(repo, pr string, groupBy types.GroupBy) error {
 	sp.Suffix = fetchingMsg
 	sp.Start()
 
-	todos, err := ghclient.CollectTODOs(ghclient.NewClient(), repo, pr)
+	todos, err := ghclient.CollectTODOs(newFetcher(), repo, pr)
 	sp.Stop()
 
 	if err != nil {
@@ -118,7 +120,7 @@ func runMain(repo, pr string, groupBy types.GroupBy) error {
 }
 
 func runCount(repo, pr string) error {
-	todos, err := ghclient.CollectTODOs(ghclient.NewClient(), repo, pr)
+	todos, err := ghclient.CollectTODOs(newFetcher(), repo, pr)
 	if err != nil {
 		return err
 	}
@@ -127,7 +129,7 @@ func runCount(repo, pr string) error {
 }
 
 func runNameOnly(repo, pr string) error {
-	todos, err := ghclient.CollectTODOs(ghclient.NewClient(), repo, pr)
+	todos, err := ghclient.CollectTODOs(newFetcher(), repo, pr)
 	if err != nil {
 		return err
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,319 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	ghclient "github.com/Suree33/gh-pr-todo/internal/github"
+	"github.com/Suree33/gh-pr-todo/pkg/types"
+	"github.com/fatih/color"
+	"github.com/spf13/pflag"
+)
+
+type stubFetcher struct {
+	diff      string
+	diffErr   error
+	files     map[string][]byte
+	filesErr  error
+	gotRepo   string
+	gotPR     string
+	gotDiffFC string
+}
+
+func (s *stubFetcher) FetchDiff(repo, pr string) (string, error) {
+	s.gotRepo, s.gotPR = repo, pr
+	return s.diff, s.diffErr
+}
+
+func (s *stubFetcher) FetchChangedFileContents(repo, pr, diff string) (map[string][]byte, error) {
+	s.gotDiffFC = diff
+	return s.files, s.filesErr
+}
+
+// withFetcher swaps the package-level newFetcher for the duration of a test.
+// Tests that use this helper MUST NOT call t.Parallel(): the swap is a global
+// mutation and would race with concurrent subtests.
+func withFetcher(t *testing.T, f ghclient.PRFetcher) {
+	t.Helper()
+	original := newFetcher
+	newFetcher = func() ghclient.PRFetcher { return f }
+	t.Cleanup(func() { newFetcher = original })
+}
+
+// captureColorOutput redirects color.Output and os.Stderr while fn runs and
+// returns whatever was written to color.Output. Like withFetcher it mutates
+// globals, so callers must not use t.Parallel().
+func captureColorOutput(t *testing.T, fn func()) string {
+	t.Helper()
+	originalColorOutput := color.Output
+	originalNoColor := color.NoColor
+	color.NoColor = true
+	var buf bytes.Buffer
+	color.Output = &buf
+	defer func() {
+		color.Output = originalColorOutput
+		color.NoColor = originalNoColor
+	}()
+
+	fn()
+	return buf.String()
+}
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	original := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() error = %v", err)
+	}
+	os.Stderr = w
+	defer func() { os.Stderr = original }()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("w.Close() error = %v", err)
+	}
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("io.ReadAll() error = %v", err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatalf("r.Close() error = %v", err)
+	}
+	return string(out)
+}
+
+const sampleDiff = `diff --git a/foo.go b/foo.go
+index 0000000..1111111 100644
+--- a/foo.go
++++ b/foo.go
+@@ -1,1 +1,2 @@
+ package foo
++// TODO: add bar
+`
+
+func TestRunMain(t *testing.T) {
+	tests := []struct {
+		name        string
+		fetcher     *stubFetcher
+		groupBy     types.GroupBy
+		wantErr     string
+		wantContain []string
+	}{
+		{
+			name:    "fetch error returned",
+			fetcher: &stubFetcher{diffErr: errors.New("diff failed")},
+			wantErr: "diff failed",
+			wantContain: []string{
+				"Fetching PR diff...",
+			},
+		},
+		{
+			name: "no TODOs prints message",
+			fetcher: &stubFetcher{
+				diff:  "",
+				files: map[string][]byte{},
+			},
+			wantContain: []string{
+				"Fetching PR diff...",
+				"No TODO comments found in the diff.",
+			},
+		},
+		{
+			name: "TODOs printed flat",
+			fetcher: &stubFetcher{
+				diff:  sampleDiff,
+				files: map[string][]byte{"foo.go": []byte("package foo\n// TODO: add bar\n")},
+			},
+			groupBy: types.GroupByNone,
+			wantContain: []string{
+				"Found 1 TODO comment(s)",
+				"foo.go:2",
+				"// TODO: add bar",
+			},
+		},
+		{
+			name: "TODOs grouped by file",
+			fetcher: &stubFetcher{
+				diff:  sampleDiff,
+				files: map[string][]byte{"foo.go": []byte("package foo\n// TODO: add bar\n")},
+			},
+			groupBy: types.GroupByFile,
+			wantContain: []string{
+				"Found 1 TODO comment(s)",
+				"foo.go",
+				"2: // TODO: add bar",
+			},
+		},
+		{
+			name: "TODOs grouped by type",
+			fetcher: &stubFetcher{
+				diff:  sampleDiff,
+				files: map[string][]byte{"foo.go": []byte("package foo\n// TODO: add bar\n")},
+			},
+			groupBy: types.GroupByType,
+			wantContain: []string{
+				"Found 1 TODO comment(s)",
+				"[TODO]",
+				"foo.go:2",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withFetcher(t, tt.fetcher)
+			var gotErr error
+			out := captureColorOutput(t, func() {
+				_ = captureStderr(t, func() {
+					gotErr = runMain("o/r", "1", tt.groupBy)
+				})
+			})
+
+			if tt.wantErr != "" {
+				if gotErr == nil || gotErr.Error() != tt.wantErr {
+					t.Fatalf("runMain() error = %v, expected %q", gotErr, tt.wantErr)
+				}
+			} else if gotErr != nil {
+				t.Fatalf("runMain() unexpected error = %v", gotErr)
+			}
+			for _, want := range tt.wantContain {
+				if !strings.Contains(out, want) {
+					t.Fatalf("runMain() output = %q, expected to contain %q", out, want)
+				}
+			}
+			if tt.fetcher.gotRepo != "o/r" || tt.fetcher.gotPR != "1" {
+				t.Fatalf("fetcher received repo=%q pr=%q, expected o/r and 1", tt.fetcher.gotRepo, tt.fetcher.gotPR)
+			}
+		})
+	}
+}
+
+func TestRunCount(t *testing.T) {
+	t.Run("fetch error returned", func(t *testing.T) {
+		withFetcher(t, &stubFetcher{diffErr: errors.New("boom")})
+		var err error
+		_ = captureColorOutput(t, func() {
+			_ = captureStderr(t, func() {
+				err = runCount("", "")
+			})
+		})
+		if err == nil || err.Error() != "boom" {
+			t.Fatalf("runCount() error = %v, expected boom", err)
+		}
+	})
+
+	t.Run("prints count on success", func(t *testing.T) {
+		withFetcher(t, &stubFetcher{
+			diff:  sampleDiff,
+			files: map[string][]byte{"foo.go": []byte("package foo\n// TODO: add bar\n")},
+		})
+		var err error
+		out := captureColorOutput(t, func() {
+			_ = captureStderr(t, func() {
+				err = runCount("o/r", "1")
+			})
+		})
+		if err != nil {
+			t.Fatalf("runCount() unexpected error = %v", err)
+		}
+		if strings.TrimSpace(out) != "1" {
+			t.Fatalf("runCount() output = %q, expected %q", out, "1")
+		}
+	})
+}
+
+func TestRunNameOnly(t *testing.T) {
+	t.Run("fetch error returned", func(t *testing.T) {
+		withFetcher(t, &stubFetcher{diffErr: errors.New("boom")})
+		var err error
+		_ = captureColorOutput(t, func() {
+			_ = captureStderr(t, func() {
+				err = runNameOnly("", "")
+			})
+		})
+		if err == nil || err.Error() != "boom" {
+			t.Fatalf("runNameOnly() error = %v, expected boom", err)
+		}
+	})
+
+	t.Run("prints file names on success", func(t *testing.T) {
+		withFetcher(t, &stubFetcher{
+			diff:  sampleDiff,
+			files: map[string][]byte{"foo.go": []byte("package foo\n// TODO: add bar\n")},
+		})
+		var err error
+		out := captureColorOutput(t, func() {
+			_ = captureStderr(t, func() {
+				err = runNameOnly("o/r", "1")
+			})
+		})
+		if err != nil {
+			t.Fatalf("runNameOnly() unexpected error = %v", err)
+		}
+		if strings.TrimSpace(out) != "foo.go" {
+			t.Fatalf("runNameOnly() output = %q, expected %q", out, "foo.go")
+		}
+	})
+
+	t.Run("no TODOs prints nothing", func(t *testing.T) {
+		withFetcher(t, &stubFetcher{diff: "", files: map[string][]byte{}})
+		var err error
+		out := captureColorOutput(t, func() {
+			_ = captureStderr(t, func() {
+				err = runNameOnly("", "")
+			})
+		})
+		if err != nil {
+			t.Fatalf("runNameOnly() unexpected error = %v", err)
+		}
+		if out != "" {
+			t.Fatalf("runNameOnly() output = %q, expected empty", out)
+		}
+	})
+}
+
+func TestPrintUsage(t *testing.T) {
+	originalCommandLine := pflag.CommandLine
+	pflag.CommandLine = pflag.NewFlagSet("gh pr-todo", pflag.ContinueOnError)
+	t.Cleanup(func() { pflag.CommandLine = originalCommandLine })
+
+	var (
+		repo     string
+		nameOnly bool
+		isCount  bool
+		isHelp   bool
+		groupBy  = types.GroupByNone
+	)
+	pflag.StringVarP(&repo, "repo", "R", "", "Select another repository using the [HOST/]OWNER/REPO format")
+	pflag.BoolVar(&nameOnly, "name-only", false, "Display only names of the files containing TODO comments")
+	pflag.BoolVarP(&isCount, "count", "c", false, "Display only the number of TODO comments")
+	pflag.BoolVarP(&isHelp, "help", "h", false, "Display help information")
+	pflag.Var(&groupBy, "group-by", "Group TODO comments by: \"file\" or \"type\"")
+
+	out := captureColorOutput(t, func() {
+		printUsage()
+	})
+
+	wantContain := []string{
+		"View TODO comments in the PR diff.",
+		"USAGE",
+		"gh pr-todo [<number> | <url> | <branch>] [flags]",
+		"FLAGS",
+		"--repo",
+		"--name-only",
+		"--count",
+		"--help",
+		"--group-by",
+	}
+	for _, want := range wantContain {
+		if !strings.Contains(out, want) {
+			t.Fatalf("printUsage() output = %q, expected to contain %q", out, want)
+		}
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -54,13 +54,23 @@ func captureColorOutput(t *testing.T, fn func()) string {
 
 func captureStderr(t *testing.T, fn func()) string {
 	t.Helper()
-	original := os.Stderr
+	return capturePipe(t, &os.Stderr, fn)
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	return capturePipe(t, &os.Stdout, fn)
+}
+
+func capturePipe(t *testing.T, target **os.File, fn func()) string {
+	t.Helper()
+	original := *target
 	r, w, err := os.Pipe()
 	if err != nil {
 		t.Fatalf("os.Pipe() error = %v", err)
 	}
-	os.Stderr = w
-	defer func() { os.Stderr = original }()
+	*target = w
+	defer func() { *target = original }()
 
 	fn()
 
@@ -211,7 +221,7 @@ func TestRunCount(t *testing.T) {
 			err       error
 			gotStderr string
 		)
-		_ = captureColorOutput(t, func() {
+		out := captureColorOutput(t, func() {
 			gotStderr = captureStderr(t, func() {
 				err = runCount(fetcher, "", "")
 			})
@@ -221,6 +231,9 @@ func TestRunCount(t *testing.T) {
 		}
 		if gotStderr != "" {
 			t.Fatalf("runCount() unexpected stderr = %q", gotStderr)
+		}
+		if out != "" {
+			t.Fatalf("runCount() unexpected stdout = %q", out)
 		}
 	})
 
@@ -260,7 +273,7 @@ func TestRunNameOnly(t *testing.T) {
 			err       error
 			gotStderr string
 		)
-		_ = captureColorOutput(t, func() {
+		out := captureColorOutput(t, func() {
 			gotStderr = captureStderr(t, func() {
 				err = runNameOnly(fetcher, "", "")
 			})
@@ -270,6 +283,9 @@ func TestRunNameOnly(t *testing.T) {
 		}
 		if gotStderr != "" {
 			t.Fatalf("runNameOnly() unexpected stderr = %q", gotStderr)
+		}
+		if out != "" {
+			t.Fatalf("runNameOnly() unexpected stdout = %q", out)
 		}
 	})
 
@@ -342,9 +358,19 @@ func TestPrintUsage(t *testing.T) {
 	pflag.BoolVarP(&isHelp, "help", "h", false, "Display help information")
 	pflag.Var(&groupBy, "group-by", "Group TODO comments by: \"file\" or \"type\"")
 
-	out := captureColorOutput(t, func() {
-		printUsage()
+	var out string
+	stdout := captureStdout(t, func() {
+		out = captureColorOutput(t, func() {
+			printUsage()
+		})
 	})
+
+	if stdout != "" {
+		t.Fatalf("printUsage() leaked to os.Stdout: %q", stdout)
+	}
+	if !strings.HasSuffix(out, "\n\n") {
+		t.Fatalf("printUsage() output should end with a blank line, got tail %q", out[max(0, len(out)-4):])
+	}
 
 	wantContain := []string{
 		"View TODO comments in the PR diff.",

--- a/main_test.go
+++ b/main_test.go
@@ -247,6 +247,9 @@ func TestRunCount(t *testing.T) {
 		if strings.TrimSpace(out) != "1" {
 			t.Fatalf("runCount() output = %q, expected %q", out, "1")
 		}
+		if fetcher.gotRepo != "o/r" || fetcher.gotPR != "1" {
+			t.Fatalf("fetcher received repo=%q pr=%q, expected o/r and 1", fetcher.gotRepo, fetcher.gotPR)
+		}
 	})
 }
 
@@ -292,6 +295,9 @@ func TestRunNameOnly(t *testing.T) {
 		}
 		if strings.TrimSpace(out) != "foo.go" {
 			t.Fatalf("runNameOnly() output = %q, expected %q", out, "foo.go")
+		}
+		if fetcher.gotRepo != "o/r" || fetcher.gotPR != "1" {
+			t.Fatalf("fetcher received repo=%q pr=%q, expected o/r and 1", fetcher.gotRepo, fetcher.gotPR)
 		}
 	})
 

--- a/main_test.go
+++ b/main_test.go
@@ -52,6 +52,18 @@ func captureColorOutput(t *testing.T, fn func()) string {
 	return buf.String()
 }
 
+// captureAll captures color.Output, os.Stdout, and os.Stderr while fn runs.
+// It mutates these globals, so callers must not use t.Parallel().
+func captureAll(t *testing.T, fn func()) (colorOut, stdout, stderr string) {
+	t.Helper()
+	stdout = captureStdout(t, func() {
+		stderr = captureStderr(t, func() {
+			colorOut = captureColorOutput(t, fn)
+		})
+	})
+	return colorOut, stdout, stderr
+}
+
 func captureStderr(t *testing.T, fn func()) string {
 	t.Helper()
 	return capturePipe(t, &os.Stderr, fn)
@@ -179,14 +191,9 @@ func TestRunMain(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var (
-				gotErr    error
-				gotStderr string
-			)
-			out := captureColorOutput(t, func() {
-				gotStderr = captureStderr(t, func() {
-					gotErr = runMain(tt.fetcher, "o/r", "1", tt.groupBy)
-				})
+			var gotErr error
+			out, stdout, gotStderr := captureAll(t, func() {
+				gotErr = runMain(tt.fetcher, "o/r", "1", tt.groupBy)
 			})
 
 			if tt.wantErr != "" {
@@ -207,6 +214,9 @@ func TestRunMain(t *testing.T) {
 			if tt.wantStderr != "" && !strings.Contains(gotStderr, tt.wantStderr) {
 				t.Fatalf("runMain() stderr = %q, expected to contain %q", gotStderr, tt.wantStderr)
 			}
+			if stdout != "" {
+				t.Fatalf("runMain() unexpected os.Stdout write = %q", stdout)
+			}
 			if tt.fetcher.gotRepo != "o/r" || tt.fetcher.gotPR != "1" {
 				t.Fatalf("fetcher received repo=%q pr=%q, expected o/r and 1", tt.fetcher.gotRepo, tt.fetcher.gotPR)
 			}
@@ -214,26 +224,29 @@ func TestRunMain(t *testing.T) {
 	}
 }
 
+func assertSilentChannels(t *testing.T, label, stdout, stderr string) {
+	t.Helper()
+	if stdout != "" {
+		t.Fatalf("%s unexpected os.Stdout write = %q", label, stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("%s unexpected os.Stderr write = %q", label, stderr)
+	}
+}
+
 func TestRunCount(t *testing.T) {
 	t.Run("fetch error returned", func(t *testing.T) {
 		fetcher := &stubFetcher{diffErr: errors.New("boom")}
-		var (
-			err       error
-			gotStderr string
-		)
-		out := captureColorOutput(t, func() {
-			gotStderr = captureStderr(t, func() {
-				err = runCount(fetcher, "", "")
-			})
+		var err error
+		out, stdout, stderr := captureAll(t, func() {
+			err = runCount(fetcher, "", "")
 		})
 		if err == nil || err.Error() != "boom" {
 			t.Fatalf("runCount() error = %v, expected boom", err)
 		}
-		if gotStderr != "" {
-			t.Fatalf("runCount() unexpected stderr = %q", gotStderr)
-		}
+		assertSilentChannels(t, "runCount()", stdout, stderr)
 		if out != "" {
-			t.Fatalf("runCount() unexpected stdout = %q", out)
+			t.Fatalf("runCount() unexpected color.Output = %q", out)
 		}
 	})
 
@@ -242,21 +255,14 @@ func TestRunCount(t *testing.T) {
 			diff:  sampleDiff,
 			files: map[string][]byte{"foo.go": []byte("package foo\n// TODO: add bar\n")},
 		}
-		var (
-			err       error
-			gotStderr string
-		)
-		out := captureColorOutput(t, func() {
-			gotStderr = captureStderr(t, func() {
-				err = runCount(fetcher, "o/r", "1")
-			})
+		var err error
+		out, stdout, stderr := captureAll(t, func() {
+			err = runCount(fetcher, "o/r", "1")
 		})
 		if err != nil {
 			t.Fatalf("runCount() unexpected error = %v", err)
 		}
-		if gotStderr != "" {
-			t.Fatalf("runCount() unexpected stderr = %q", gotStderr)
-		}
+		assertSilentChannels(t, "runCount()", stdout, stderr)
 		if strings.TrimSpace(out) != "1" {
 			t.Fatalf("runCount() output = %q, expected %q", out, "1")
 		}
@@ -269,23 +275,16 @@ func TestRunCount(t *testing.T) {
 func TestRunNameOnly(t *testing.T) {
 	t.Run("fetch error returned", func(t *testing.T) {
 		fetcher := &stubFetcher{diffErr: errors.New("boom")}
-		var (
-			err       error
-			gotStderr string
-		)
-		out := captureColorOutput(t, func() {
-			gotStderr = captureStderr(t, func() {
-				err = runNameOnly(fetcher, "", "")
-			})
+		var err error
+		out, stdout, stderr := captureAll(t, func() {
+			err = runNameOnly(fetcher, "", "")
 		})
 		if err == nil || err.Error() != "boom" {
 			t.Fatalf("runNameOnly() error = %v, expected boom", err)
 		}
-		if gotStderr != "" {
-			t.Fatalf("runNameOnly() unexpected stderr = %q", gotStderr)
-		}
+		assertSilentChannels(t, "runNameOnly()", stdout, stderr)
 		if out != "" {
-			t.Fatalf("runNameOnly() unexpected stdout = %q", out)
+			t.Fatalf("runNameOnly() unexpected color.Output = %q", out)
 		}
 	})
 
@@ -294,21 +293,14 @@ func TestRunNameOnly(t *testing.T) {
 			diff:  sampleDiff,
 			files: map[string][]byte{"foo.go": []byte("package foo\n// TODO: add bar\n")},
 		}
-		var (
-			err       error
-			gotStderr string
-		)
-		out := captureColorOutput(t, func() {
-			gotStderr = captureStderr(t, func() {
-				err = runNameOnly(fetcher, "o/r", "1")
-			})
+		var err error
+		out, stdout, stderr := captureAll(t, func() {
+			err = runNameOnly(fetcher, "o/r", "1")
 		})
 		if err != nil {
 			t.Fatalf("runNameOnly() unexpected error = %v", err)
 		}
-		if gotStderr != "" {
-			t.Fatalf("runNameOnly() unexpected stderr = %q", gotStderr)
-		}
+		assertSilentChannels(t, "runNameOnly()", stdout, stderr)
 		if strings.TrimSpace(out) != "foo.go" {
 			t.Fatalf("runNameOnly() output = %q, expected %q", out, "foo.go")
 		}
@@ -319,21 +311,14 @@ func TestRunNameOnly(t *testing.T) {
 
 	t.Run("no TODOs prints nothing", func(t *testing.T) {
 		fetcher := &stubFetcher{diff: "", files: map[string][]byte{}}
-		var (
-			err       error
-			gotStderr string
-		)
-		out := captureColorOutput(t, func() {
-			gotStderr = captureStderr(t, func() {
-				err = runNameOnly(fetcher, "", "")
-			})
+		var err error
+		out, stdout, stderr := captureAll(t, func() {
+			err = runNameOnly(fetcher, "", "")
 		})
 		if err != nil {
 			t.Fatalf("runNameOnly() unexpected error = %v", err)
 		}
-		if gotStderr != "" {
-			t.Fatalf("runNameOnly() unexpected stderr = %q", gotStderr)
-		}
+		assertSilentChannels(t, "runNameOnly()", stdout, stderr)
 		if out != "" {
 			t.Fatalf("runNameOnly() output = %q, expected empty", out)
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	ghclient "github.com/Suree33/gh-pr-todo/internal/github"
 	"github.com/Suree33/gh-pr-todo/pkg/types"
 	"github.com/fatih/color"
 	"github.com/spf13/pflag"
@@ -34,19 +33,9 @@ func (s *stubFetcher) FetchChangedFileContents(repo, pr, diff string) (map[strin
 	return s.files, s.filesErr
 }
 
-// withFetcher swaps the package-level newFetcher for the duration of a test.
-// Tests that use this helper MUST NOT call t.Parallel(): the swap is a global
-// mutation and would race with concurrent subtests.
-func withFetcher(t *testing.T, f ghclient.PRFetcher) {
-	t.Helper()
-	original := newFetcher
-	newFetcher = func() ghclient.PRFetcher { return f }
-	t.Cleanup(func() { newFetcher = original })
-}
-
-// captureColorOutput redirects color.Output and os.Stderr while fn runs and
-// returns whatever was written to color.Output. Like withFetcher it mutates
-// globals, so callers must not use t.Parallel().
+// captureColorOutput redirects color.Output while fn runs and returns whatever
+// was written there. It mutates the global color.Output and color.NoColor, so
+// callers must not use t.Parallel().
 func captureColorOutput(t *testing.T, fn func()) string {
 	t.Helper()
 	originalColorOutput := color.Output
@@ -104,6 +93,7 @@ func TestRunMain(t *testing.T) {
 		groupBy     types.GroupBy
 		wantErr     string
 		wantContain []string
+		wantStderr  string
 	}{
 		{
 			name:    "fetch error returned",
@@ -163,15 +153,29 @@ func TestRunMain(t *testing.T) {
 				"foo.go:2",
 			},
 		},
+		{
+			name: "FetchChangedFileContents error logs warning and continues",
+			fetcher: &stubFetcher{
+				diff:     sampleDiff,
+				files:    nil,
+				filesErr: errors.New("contents failed"),
+			},
+			wantContain: []string{
+				"Found 1 TODO comment(s)",
+			},
+			wantStderr: "Warning: could not fetch changed file contents",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			withFetcher(t, tt.fetcher)
-			var gotErr error
+			var (
+				gotErr    error
+				gotStderr string
+			)
 			out := captureColorOutput(t, func() {
-				_ = captureStderr(t, func() {
-					gotErr = runMain("o/r", "1", tt.groupBy)
+				gotStderr = captureStderr(t, func() {
+					gotErr = runMain(tt.fetcher, "o/r", "1", tt.groupBy)
 				})
 			})
 
@@ -187,6 +191,12 @@ func TestRunMain(t *testing.T) {
 					t.Fatalf("runMain() output = %q, expected to contain %q", out, want)
 				}
 			}
+			if tt.wantStderr == "" && gotStderr != "" {
+				t.Fatalf("runMain() unexpected stderr = %q", gotStderr)
+			}
+			if tt.wantStderr != "" && !strings.Contains(gotStderr, tt.wantStderr) {
+				t.Fatalf("runMain() stderr = %q, expected to contain %q", gotStderr, tt.wantStderr)
+			}
 			if tt.fetcher.gotRepo != "o/r" || tt.fetcher.gotPR != "1" {
 				t.Fatalf("fetcher received repo=%q pr=%q, expected o/r and 1", tt.fetcher.gotRepo, tt.fetcher.gotPR)
 			}
@@ -196,31 +206,43 @@ func TestRunMain(t *testing.T) {
 
 func TestRunCount(t *testing.T) {
 	t.Run("fetch error returned", func(t *testing.T) {
-		withFetcher(t, &stubFetcher{diffErr: errors.New("boom")})
-		var err error
+		fetcher := &stubFetcher{diffErr: errors.New("boom")}
+		var (
+			err       error
+			gotStderr string
+		)
 		_ = captureColorOutput(t, func() {
-			_ = captureStderr(t, func() {
-				err = runCount("", "")
+			gotStderr = captureStderr(t, func() {
+				err = runCount(fetcher, "", "")
 			})
 		})
 		if err == nil || err.Error() != "boom" {
 			t.Fatalf("runCount() error = %v, expected boom", err)
 		}
+		if gotStderr != "" {
+			t.Fatalf("runCount() unexpected stderr = %q", gotStderr)
+		}
 	})
 
 	t.Run("prints count on success", func(t *testing.T) {
-		withFetcher(t, &stubFetcher{
+		fetcher := &stubFetcher{
 			diff:  sampleDiff,
 			files: map[string][]byte{"foo.go": []byte("package foo\n// TODO: add bar\n")},
-		})
-		var err error
+		}
+		var (
+			err       error
+			gotStderr string
+		)
 		out := captureColorOutput(t, func() {
-			_ = captureStderr(t, func() {
-				err = runCount("o/r", "1")
+			gotStderr = captureStderr(t, func() {
+				err = runCount(fetcher, "o/r", "1")
 			})
 		})
 		if err != nil {
 			t.Fatalf("runCount() unexpected error = %v", err)
+		}
+		if gotStderr != "" {
+			t.Fatalf("runCount() unexpected stderr = %q", gotStderr)
 		}
 		if strings.TrimSpace(out) != "1" {
 			t.Fatalf("runCount() output = %q, expected %q", out, "1")
@@ -230,31 +252,43 @@ func TestRunCount(t *testing.T) {
 
 func TestRunNameOnly(t *testing.T) {
 	t.Run("fetch error returned", func(t *testing.T) {
-		withFetcher(t, &stubFetcher{diffErr: errors.New("boom")})
-		var err error
+		fetcher := &stubFetcher{diffErr: errors.New("boom")}
+		var (
+			err       error
+			gotStderr string
+		)
 		_ = captureColorOutput(t, func() {
-			_ = captureStderr(t, func() {
-				err = runNameOnly("", "")
+			gotStderr = captureStderr(t, func() {
+				err = runNameOnly(fetcher, "", "")
 			})
 		})
 		if err == nil || err.Error() != "boom" {
 			t.Fatalf("runNameOnly() error = %v, expected boom", err)
 		}
+		if gotStderr != "" {
+			t.Fatalf("runNameOnly() unexpected stderr = %q", gotStderr)
+		}
 	})
 
 	t.Run("prints file names on success", func(t *testing.T) {
-		withFetcher(t, &stubFetcher{
+		fetcher := &stubFetcher{
 			diff:  sampleDiff,
 			files: map[string][]byte{"foo.go": []byte("package foo\n// TODO: add bar\n")},
-		})
-		var err error
+		}
+		var (
+			err       error
+			gotStderr string
+		)
 		out := captureColorOutput(t, func() {
-			_ = captureStderr(t, func() {
-				err = runNameOnly("o/r", "1")
+			gotStderr = captureStderr(t, func() {
+				err = runNameOnly(fetcher, "o/r", "1")
 			})
 		})
 		if err != nil {
 			t.Fatalf("runNameOnly() unexpected error = %v", err)
+		}
+		if gotStderr != "" {
+			t.Fatalf("runNameOnly() unexpected stderr = %q", gotStderr)
 		}
 		if strings.TrimSpace(out) != "foo.go" {
 			t.Fatalf("runNameOnly() output = %q, expected %q", out, "foo.go")
@@ -262,15 +296,21 @@ func TestRunNameOnly(t *testing.T) {
 	})
 
 	t.Run("no TODOs prints nothing", func(t *testing.T) {
-		withFetcher(t, &stubFetcher{diff: "", files: map[string][]byte{}})
-		var err error
+		fetcher := &stubFetcher{diff: "", files: map[string][]byte{}}
+		var (
+			err       error
+			gotStderr string
+		)
 		out := captureColorOutput(t, func() {
-			_ = captureStderr(t, func() {
-				err = runNameOnly("", "")
+			gotStderr = captureStderr(t, func() {
+				err = runNameOnly(fetcher, "", "")
 			})
 		})
 		if err != nil {
 			t.Fatalf("runNameOnly() unexpected error = %v", err)
+		}
+		if gotStderr != "" {
+			t.Fatalf("runNameOnly() unexpected stderr = %q", gotStderr)
 		}
 		if out != "" {
 			t.Fatalf("runNameOnly() output = %q, expected empty", out)


### PR DESCRIPTION
## Summary

Add tests for the previously-untested root `main` package and tighten existing tests in `internal/github` based on iterative oracle reviews.

## Changes

### `main.go`
- Refactor `runMain`/`runCount`/`runNameOnly` to accept `ghclient.PRFetcher` explicitly instead of constructing it inside, enabling stub-based testing without global mutation
- Switch `printUsage`'s trailing newline from `fmt.Println()` to `fmt.Fprintln(color.Output)` so all output goes through one writer

### `main_test.go` (new)
- Table-driven tests for `runMain` covering: fetch error, no TODOs, flat output, group-by-file, group-by-type, and `FetchChangedFileContents` warning fallback
- Subtests for `runCount` and `runNameOnly` covering error and success paths plus repo/pr forwarding
- `TestPrintUsage` covers all flag rendering and asserts no leak to real `os.Stdout`
- `captureAll` helper redirects `color.Output`, `os.Stdout`, and `os.Stderr` together; `assertSilentChannels` keeps subtests concise

### `internal/github/client_test.go`
- Symmetrize stderr assertions: also assert empty stderr on success paths and on `FetchDiff` error path
- Strengthen `TestCollectTODOs` with `reflect.DeepEqual` comparison of returned TODOs
- Track `fetchFCCalled` to prove `FetchChangedFileContents` is short-circuited when `FetchDiff` fails
- Verify `repo`/`pr` are forwarded to both fetcher methods

## Verification

- `go test ./...` — all pass
- `golangci-lint run` — 0 issues

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/suree33/gh-pr-todo/pull/66" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
