### PR TITLE
ci(workflow): add actionlint job and refactor CI with YAML anchors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,13 +19,16 @@ defaults:
 
 jobs:
   lint:
+    name: Lint
     timeout-minutes: 15
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - &checkout
+        uses: actions/checkout@v6
 
-      - name: Setup Go
+      - &setup-go
+        name: Setup Go
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
@@ -34,6 +37,7 @@ jobs:
         uses: golangci/golangci-lint-action@v9
 
   build:
+    name: Build
     needs: lint
     timeout-minutes: 15
     strategy:
@@ -43,17 +47,14 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v6
-
-      - name: Setup Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
+      - *checkout
+      - *setup-go
 
       - name: Build
         run: go build -v ./...
 
   test:
+    name: Test
     needs: lint
     timeout-minutes: 15
     strategy:
@@ -63,12 +64,19 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v6
-
-      - name: Setup Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
+      - *checkout
+      - *setup-go
 
       - name: Test
         run: go test -v ./...
+
+  actionlint:
+    name: Actionlint
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+
+    steps:
+      - *checkout
+
+      - name: Actionlint
+        run: docker run --rm -v "$(pwd):$(pwd)" -w "$(pwd)" rhysd/actionlint:latest -color


### PR DESCRIPTION
## Summary

- YAML アンカー (`&checkout`, `&setup-go`) で checkout / setup-go ステップの重複を削除
- 各ジョブに `name` を明示的に追加し可読性を向上
- GitHub Actions ワークフロー自体を lint する `actionlint` ジョブを追加
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/suree33/gh-pr-todo/pull/69" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
