### PR TITLE
feat(ci): exit non-zero when TODOs are detected in CI environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,22 @@ gh pr-todo --group-by file
 - `--group-by`: Group TODO comments by file or type
 - `--name-only`: Display only names of the files containing TODO comments
 - `-c, --count`: Display only the number of TODO comments
+- `--no-ci-fail`: Disable non-zero exit when TODOs are found in CI (see below)
+
+### CI Mode
+
+When the `CI` environment variable is set to a truthy value (e.g. `1`, `true`, parsed via Go's `strconv.ParseBool`), `gh pr-todo` exits with status `1` if any TODO-style comments are detected in the PR diff. This makes it easy to fail a CI job when new TODOs slip into a pull request.
+
+```yaml
+# GitHub Actions example — CI=true is set automatically
+- run: gh pr-todo ${{ github.event.pull_request.number }}
+```
+
+Pass `--no-ci-fail` to keep the informational behavior even in CI:
+
+```bash
+gh pr-todo --count --no-ci-fail
+```
 
 ### Example Output
 

--- a/main.go
+++ b/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 	"os"
+	"strconv"
+	"strings"
 	"time"
 
 	ghclient "github.com/Suree33/gh-pr-todo/internal/github"
@@ -19,12 +21,14 @@ func main() {
 		nameOnly bool
 		isCount  bool
 		isHelp   bool
+		noCIFail bool
 		groupBy  = types.GroupByNone
 	)
 	pflag.StringVarP(&repo, "repo", "R", "", "Select another repository using the [HOST/]OWNER/REPO format")
 	pflag.BoolVar(&nameOnly, "name-only", false, "Display only names of the files containing TODO comments")
 	pflag.BoolVarP(&isCount, "count", "c", false, "Display only the number of TODO comments")
 	pflag.BoolVarP(&isHelp, "help", "h", false, "Display help information")
+	pflag.BoolVar(&noCIFail, "no-ci-fail", false, "Disable non-zero exit when TODOs are found in CI")
 	pflag.Var(&groupBy, "group-by", "Group TODO comments by: \"file\" or \"type\"")
 	pflag.Usage = printUsage
 	pflag.Parse()
@@ -67,19 +71,24 @@ func main() {
 	}
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
 	}
-	if count > 0 && isCI() {
-		os.Exit(1)
+	os.Exit(exitCode(err, count, isCI(), noCIFail))
+}
+
+func exitCode(err error, count int, ci, noCIFail bool) int {
+	if err != nil {
+		return 1
 	}
+	if ci && !noCIFail && count > 0 {
+		return 1
+	}
+	return 0
 }
 
 func isCI() bool {
-	switch os.Getenv("CI") {
-	case "1", "true":
-		return true
-	}
-	return false
+	v := strings.TrimSpace(os.Getenv("CI"))
+	ok, err := strconv.ParseBool(v)
+	return err == nil && ok
 }
 
 func printUsage() {
@@ -105,6 +114,9 @@ func printUsage() {
 		}
 	})
 	fmt.Fprintln(color.Output)
+	fmt.Fprintf(color.Output, "%s\n", output.Bold("ENVIRONMENT"))
+	fmt.Fprintf(color.Output, "  %s\n", "CI  When truthy (e.g. \"1\", \"true\"), exits non-zero if any TODO is found.")
+	fmt.Fprintf(color.Output, "  %s\n\n", "    Override with --no-ci-fail.")
 }
 
 func runMain(fetcher ghclient.PRFetcher, repo, pr string, groupBy types.GroupBy) (int, error) {

--- a/main.go
+++ b/main.go
@@ -53,19 +53,33 @@ func main() {
 	}
 
 	fetcher := ghclient.NewClient()
-	var err error
+	var (
+		err   error
+		count int
+	)
 	switch {
 	case nameOnly:
-		err = runNameOnly(fetcher, repo, pr)
+		count, err = runNameOnly(fetcher, repo, pr)
 	case isCount:
-		err = runCount(fetcher, repo, pr)
+		count, err = runCount(fetcher, repo, pr)
 	default:
-		err = runMain(fetcher, repo, pr, groupBy)
+		count, err = runMain(fetcher, repo, pr, groupBy)
 	}
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+	if count > 0 && isCI() {
+		os.Exit(1)
+	}
+}
+
+func isCI() bool {
+	switch os.Getenv("CI") {
+	case "1", "true":
+		return true
+	}
+	return false
 }
 
 func printUsage() {
@@ -93,7 +107,7 @@ func printUsage() {
 	fmt.Fprintln(color.Output)
 }
 
-func runMain(fetcher ghclient.PRFetcher, repo, pr string, groupBy types.GroupBy) error {
+func runMain(fetcher ghclient.PRFetcher, repo, pr string, groupBy types.GroupBy) (int, error) {
 	sp := spinner.New(spinner.CharSets[14], 40*time.Millisecond)
 	fetchingMsg := " Fetching PR diff..."
 	sp.Suffix = fetchingMsg
@@ -104,34 +118,34 @@ func runMain(fetcher ghclient.PRFetcher, repo, pr string, groupBy types.GroupBy)
 
 	if err != nil {
 		fmt.Fprintf(color.Output, "%s%s\n", output.Red("✗"), fetchingMsg)
-		return err
+		return 0, err
 	}
 	fmt.Fprintf(color.Output, "%s%s\n", output.Green("✔"), fetchingMsg)
 
 	if len(todos) == 0 {
 		fmt.Fprintf(color.Output, "\nNo TODO comments found in the diff.\n")
-		return nil
+		return 0, nil
 	}
 
 	fmt.Fprintf(color.Output, output.Bold("\nFound %d TODO comment(s)\n\n"), len(todos))
 	output.PrintTODOs(todos, groupBy)
-	return nil
+	return len(todos), nil
 }
 
-func runCount(fetcher ghclient.PRFetcher, repo, pr string) error {
+func runCount(fetcher ghclient.PRFetcher, repo, pr string) (int, error) {
 	todos, err := ghclient.CollectTODOs(fetcher, repo, pr)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	output.PrintCount(todos)
-	return nil
+	return len(todos), nil
 }
 
-func runNameOnly(fetcher ghclient.PRFetcher, repo, pr string) error {
+func runNameOnly(fetcher ghclient.PRFetcher, repo, pr string) (int, error) {
 	todos, err := ghclient.CollectTODOs(fetcher, repo, pr)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	output.PrintFileNames(todos)
-	return nil
+	return len(todos), nil
 }

--- a/main_test.go
+++ b/main_test.go
@@ -336,24 +336,57 @@ func TestIsCI(t *testing.T) {
 		{name: "empty returns false", value: "", set: true, want: false},
 		{name: "CI=1 returns true", value: "1", set: true, want: true},
 		{name: "CI=true returns true", value: "true", set: true, want: true},
+		{name: "CI=True (mixed case) returns true", value: "True", set: true, want: true},
+		{name: "CI=TRUE (uppercase) returns true", value: "TRUE", set: true, want: true},
+		{name: "CI=t returns true", value: "t", set: true, want: true},
+		{name: "CI=T returns true", value: "T", set: true, want: true},
+		{name: " CI= surrounded by whitespace returns true", value: "  true  ", set: true, want: true},
 		{name: "CI=false returns false", value: "false", set: true, want: false},
 		{name: "CI=0 returns false", value: "0", set: true, want: false},
-		{name: "CI=TRUE (uppercase) returns false", value: "TRUE", set: true, want: false},
 		{name: "CI=yes returns false", value: "yes", set: true, want: false},
+		{name: "CI=on returns false", value: "on", set: true, want: false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv("CI", "")
 			if tt.set {
 				t.Setenv("CI", tt.value)
 			} else {
 				if err := os.Unsetenv("CI"); err != nil {
 					t.Fatalf("os.Unsetenv() error = %v", err)
 				}
+				t.Cleanup(func() { _ = os.Unsetenv("CI") })
 			}
 			if got := isCI(); got != tt.want {
 				t.Fatalf("isCI() = %v, expected %v (CI set=%v value=%q)", got, tt.want, tt.set, tt.value)
+			}
+		})
+	}
+}
+
+func TestExitCode(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		count    int
+		ci       bool
+		noCIFail bool
+		want     int
+	}{
+		{name: "error returns 1", err: errors.New("boom"), want: 1},
+		{name: "error in CI still 1", err: errors.New("boom"), ci: true, count: 5, want: 1},
+		{name: "no error no TODOs returns 0", want: 0},
+		{name: "no error TODOs not in CI returns 0", count: 3, want: 0},
+		{name: "no error TODOs in CI returns 1", count: 3, ci: true, want: 1},
+		{name: "no error TODOs in CI with no-ci-fail returns 0", count: 3, ci: true, noCIFail: true, want: 0},
+		{name: "no error zero TODOs in CI returns 0", count: 0, ci: true, want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := exitCode(tt.err, tt.count, tt.ci, tt.noCIFail); got != tt.want {
+				t.Fatalf("exitCode(err=%v, count=%d, ci=%v, noCIFail=%v) = %d, expected %d",
+					tt.err, tt.count, tt.ci, tt.noCIFail, got, tt.want)
 			}
 		})
 	}
@@ -500,12 +533,14 @@ func TestPrintUsage(t *testing.T) {
 		nameOnly bool
 		isCount  bool
 		isHelp   bool
+		noCIFail bool
 		groupBy  = types.GroupByNone
 	)
 	pflag.StringVarP(&repo, "repo", "R", "", "Select another repository using the [HOST/]OWNER/REPO format")
 	pflag.BoolVar(&nameOnly, "name-only", false, "Display only names of the files containing TODO comments")
 	pflag.BoolVarP(&isCount, "count", "c", false, "Display only the number of TODO comments")
 	pflag.BoolVarP(&isHelp, "help", "h", false, "Display help information")
+	pflag.BoolVar(&noCIFail, "no-ci-fail", false, "Disable non-zero exit when TODOs are found in CI")
 	pflag.Var(&groupBy, "group-by", "Group TODO comments by: \"file\" or \"type\"")
 
 	var out string
@@ -532,6 +567,9 @@ func TestPrintUsage(t *testing.T) {
 		"--count",
 		"--help",
 		"--group-by",
+		"--no-ci-fail",
+		"ENVIRONMENT",
+		"CI",
 	}
 	for _, want := range wantContain {
 		if !strings.Contains(out, want) {

--- a/main_test.go
+++ b/main_test.go
@@ -193,7 +193,7 @@ func TestRunMain(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var gotErr error
 			out, stdout, gotStderr := captureAll(t, func() {
-				gotErr = runMain(tt.fetcher, "o/r", "1", tt.groupBy)
+				_, gotErr = runMain(tt.fetcher, "o/r", "1", tt.groupBy)
 			})
 
 			if tt.wantErr != "" {
@@ -239,7 +239,7 @@ func TestRunCount(t *testing.T) {
 		fetcher := &stubFetcher{diffErr: errors.New("boom")}
 		var err error
 		out, stdout, stderr := captureAll(t, func() {
-			err = runCount(fetcher, "", "")
+			_, err = runCount(fetcher, "", "")
 		})
 		if err == nil || err.Error() != "boom" {
 			t.Fatalf("runCount() error = %v, expected boom", err)
@@ -257,7 +257,7 @@ func TestRunCount(t *testing.T) {
 		}
 		var err error
 		out, stdout, stderr := captureAll(t, func() {
-			err = runCount(fetcher, "o/r", "1")
+			_, err = runCount(fetcher, "o/r", "1")
 		})
 		if err != nil {
 			t.Fatalf("runCount() unexpected error = %v", err)
@@ -277,7 +277,7 @@ func TestRunNameOnly(t *testing.T) {
 		fetcher := &stubFetcher{diffErr: errors.New("boom")}
 		var err error
 		out, stdout, stderr := captureAll(t, func() {
-			err = runNameOnly(fetcher, "", "")
+			_, err = runNameOnly(fetcher, "", "")
 		})
 		if err == nil || err.Error() != "boom" {
 			t.Fatalf("runNameOnly() error = %v, expected boom", err)
@@ -295,7 +295,7 @@ func TestRunNameOnly(t *testing.T) {
 		}
 		var err error
 		out, stdout, stderr := captureAll(t, func() {
-			err = runNameOnly(fetcher, "o/r", "1")
+			_, err = runNameOnly(fetcher, "o/r", "1")
 		})
 		if err != nil {
 			t.Fatalf("runNameOnly() unexpected error = %v", err)
@@ -313,7 +313,7 @@ func TestRunNameOnly(t *testing.T) {
 		fetcher := &stubFetcher{diff: "", files: map[string][]byte{}}
 		var err error
 		out, stdout, stderr := captureAll(t, func() {
-			err = runNameOnly(fetcher, "", "")
+			_, err = runNameOnly(fetcher, "", "")
 		})
 		if err != nil {
 			t.Fatalf("runNameOnly() unexpected error = %v", err)
@@ -321,6 +321,171 @@ func TestRunNameOnly(t *testing.T) {
 		assertSilentChannels(t, "runNameOnly()", stdout, stderr)
 		if out != "" {
 			t.Fatalf("runNameOnly() output = %q, expected empty", out)
+		}
+	})
+}
+
+func TestIsCI(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		set   bool
+		want  bool
+	}{
+		{name: "unset returns false", set: false, want: false},
+		{name: "empty returns false", value: "", set: true, want: false},
+		{name: "CI=1 returns true", value: "1", set: true, want: true},
+		{name: "CI=true returns true", value: "true", set: true, want: true},
+		{name: "CI=false returns false", value: "false", set: true, want: false},
+		{name: "CI=0 returns false", value: "0", set: true, want: false},
+		{name: "CI=TRUE (uppercase) returns false", value: "TRUE", set: true, want: false},
+		{name: "CI=yes returns false", value: "yes", set: true, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("CI", "")
+			if tt.set {
+				t.Setenv("CI", tt.value)
+			} else {
+				if err := os.Unsetenv("CI"); err != nil {
+					t.Fatalf("os.Unsetenv() error = %v", err)
+				}
+			}
+			if got := isCI(); got != tt.want {
+				t.Fatalf("isCI() = %v, expected %v (CI set=%v value=%q)", got, tt.want, tt.set, tt.value)
+			}
+		})
+	}
+}
+
+func TestRunFunctionsReturnTODOCount(t *testing.T) {
+	twoTODOsDiff := `diff --git a/foo.go b/foo.go
+index 0000000..1111111 100644
+--- a/foo.go
++++ b/foo.go
+@@ -1,1 +1,3 @@
+ package foo
++// TODO: add bar
++// FIXME: fix baz
+`
+	twoTODOsFiles := map[string][]byte{
+		"foo.go": []byte("package foo\n// TODO: add bar\n// FIXME: fix baz\n"),
+	}
+
+	tests := []struct {
+		name      string
+		fetcher   *stubFetcher
+		wantCount int
+	}{
+		{
+			name:      "no TODOs returns 0",
+			fetcher:   &stubFetcher{diff: "", files: map[string][]byte{}},
+			wantCount: 0,
+		},
+		{
+			name: "one TODO returns 1",
+			fetcher: &stubFetcher{
+				diff:  sampleDiff,
+				files: map[string][]byte{"foo.go": []byte("package foo\n// TODO: add bar\n")},
+			},
+			wantCount: 1,
+		},
+		{
+			name:      "two TODOs returns 2",
+			fetcher:   &stubFetcher{diff: twoTODOsDiff, files: twoTODOsFiles},
+			wantCount: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run("runMain/"+tt.name, func(t *testing.T) {
+			var gotCount int
+			var gotErr error
+			_, _, _ = captureAll(t, func() {
+				gotCount, gotErr = runMain(tt.fetcher, "o/r", "1", types.GroupByNone)
+			})
+			if gotErr != nil {
+				t.Fatalf("runMain() unexpected error = %v", gotErr)
+			}
+			if gotCount != tt.wantCount {
+				t.Fatalf("runMain() count = %d, expected %d", gotCount, tt.wantCount)
+			}
+		})
+
+		t.Run("runCount/"+tt.name, func(t *testing.T) {
+			var gotCount int
+			var gotErr error
+			_, _, _ = captureAll(t, func() {
+				gotCount, gotErr = runCount(tt.fetcher, "o/r", "1")
+			})
+			if gotErr != nil {
+				t.Fatalf("runCount() unexpected error = %v", gotErr)
+			}
+			if gotCount != tt.wantCount {
+				t.Fatalf("runCount() count = %d, expected %d", gotCount, tt.wantCount)
+			}
+		})
+
+		t.Run("runNameOnly/"+tt.name, func(t *testing.T) {
+			var gotCount int
+			var gotErr error
+			_, _, _ = captureAll(t, func() {
+				gotCount, gotErr = runNameOnly(tt.fetcher, "o/r", "1")
+			})
+			if gotErr != nil {
+				t.Fatalf("runNameOnly() unexpected error = %v", gotErr)
+			}
+			if gotCount != tt.wantCount {
+				t.Fatalf("runNameOnly() count = %d, expected %d", gotCount, tt.wantCount)
+			}
+		})
+	}
+}
+
+func TestRunFunctionsReturnZeroCountOnError(t *testing.T) {
+	t.Run("runMain", func(t *testing.T) {
+		fetcher := &stubFetcher{diffErr: errors.New("boom")}
+		var gotCount int
+		var gotErr error
+		_, _, _ = captureAll(t, func() {
+			gotCount, gotErr = runMain(fetcher, "", "", types.GroupByNone)
+		})
+		if gotErr == nil {
+			t.Fatalf("runMain() expected error, got nil")
+		}
+		if gotCount != 0 {
+			t.Fatalf("runMain() count = %d, expected 0", gotCount)
+		}
+	})
+
+	t.Run("runCount", func(t *testing.T) {
+		fetcher := &stubFetcher{diffErr: errors.New("boom")}
+		var gotCount int
+		var gotErr error
+		_, _, _ = captureAll(t, func() {
+			gotCount, gotErr = runCount(fetcher, "", "")
+		})
+		if gotErr == nil {
+			t.Fatalf("runCount() expected error, got nil")
+		}
+		if gotCount != 0 {
+			t.Fatalf("runCount() count = %d, expected 0", gotCount)
+		}
+	})
+
+	t.Run("runNameOnly", func(t *testing.T) {
+		fetcher := &stubFetcher{diffErr: errors.New("boom")}
+		var gotCount int
+		var gotErr error
+		_, _, _ = captureAll(t, func() {
+			gotCount, gotErr = runNameOnly(fetcher, "", "")
+		})
+		if gotErr == nil {
+			t.Fatalf("runNameOnly() expected error, got nil")
+		}
+		if gotCount != 0 {
+			t.Fatalf("runNameOnly() count = %d, expected 0", gotCount)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Make `gh pr-todo` exit with status `1` when running in CI and any TODO-style comment is detected in the PR diff. This lets a CI job fail when new TODOs slip into a pull request.

### Behavior

- When the `CI` env var is truthy (parsed via `strconv.ParseBool`: `1`, `true`, `True`, `TRUE`, `t`, `T`, with surrounding whitespace tolerated), exit `1` if any TODO is found.
- Pass `--no-ci-fail` to keep the previous informational behavior even in CI.
- Errors still exit `1` regardless of CI.
- No-TODO runs still exit `0`.

### Changes

- `main.go`
  - New `isCI()` using `strconv.ParseBool` (case-insensitive, whitespace-tolerant)
  - New `exitCode(err, count, ci, noCIFail)` helper centralizing the exit decision
  - `runMain` / `runCount` / `runNameOnly` now also return the TODO count so `main` can act on it
  - New `--no-ci-fail` flag
  - `printUsage` gained an `ENVIRONMENT` section documenting the `CI` contract
- `README.md`: added a **CI Mode** section with a GitHub Actions example
- `main_test.go`
  - `TestIsCI`: env-var matrix (true/false/whitespace/case)
  - `TestExitCode`: full decision matrix (error / count / ci / noCIFail)
  - `TestRunFunctionsReturnTODOCount` and `TestRunFunctionsReturnZeroCountOnError`
  - Existing tests updated for new `(int, error)` signature

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/suree33/gh-pr-todo/pull/70" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
