### PR TITLE
feat(output): emit GitHub Actions workflow commands for TODOs

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,15 @@ Pass `--no-ci-fail` to keep the informational behavior even in CI:
 gh pr-todo --count --no-ci-fail
 ```
 
+### GitHub Actions Annotations
+
+When `GITHUB_ACTIONS=true` (set automatically by the GitHub Actions runner), `gh pr-todo` additionally emits [workflow commands](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands) so each TODO appears as an annotation on the workflow run and pull request:
+
+- `TODO`, `NOTE` → `::notice` annotations
+- `FIXME`, `HACK`, `XXX`, `BUG` → `::warning` annotations
+
+Each annotation is anchored to the file and line of the TODO, with the keyword used as the annotation title. Regular human-readable output is still printed.
+
 ### Example Output
 
 ```

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ gh pr-todo --group-by file
 
 ### CI Mode
 
-When the `CI` environment variable is set to a truthy value (e.g. `1`, `true`, parsed via Go's `strconv.ParseBool`), `gh pr-todo` exits with status `1` if any TODO-style comments are detected in the PR diff. This makes it easy to fail a CI job when new TODOs slip into a pull request.
+When the `CI` environment variable is set to a truthy value (e.g. `1`, `true`, parsed via Go's `strconv.ParseBool`), `gh pr-todo` exits with status `1` if any TODO-style comments are detected in the PR diff. This makes it easy to fail a CI job when new TODOs slip into a pull request. `GITHUB_ACTIONS=true` (set automatically by the GitHub Actions runner) is treated as `CI=true` even when the `CI` variable is missing or falsy.
 
 ```yaml
 # GitHub Actions example — CI=true is set automatically

--- a/README.md
+++ b/README.md
@@ -94,7 +94,9 @@ When `GITHUB_ACTIONS=true` (set automatically by the GitHub Actions runner), `gh
 - `TODO`, `NOTE` → `::notice` annotations
 - `FIXME`, `HACK`, `XXX`, `BUG` → `::warning` annotations
 
-Each annotation is anchored to the file and line of the TODO, with the keyword used as the annotation title. Regular human-readable output is still printed.
+Each annotation is anchored to the file and line of the TODO, with the keyword used as the annotation title. Regular human-readable output is still printed, and the spinner is suppressed to keep Actions logs clean.
+
+Workflow commands are only emitted in the default mode. The machine-readable modes `--count` and `--name-only` keep their plain output unchanged so that `count=$(gh pr-todo --count)` and similar shell pipelines stay reliable in Actions.
 
 ### Example Output
 

--- a/internal/output/workflow.go
+++ b/internal/output/workflow.go
@@ -1,0 +1,48 @@
+package output
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Suree33/gh-pr-todo/pkg/types"
+	"github.com/fatih/color"
+)
+
+// PrintWorkflowCommands writes a GitHub Actions workflow command annotation
+// for each TODO so that they show up in the PR/check-run UI.
+//
+// See https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands
+func PrintWorkflowCommands(todos []types.TODO) {
+	for _, todo := range todos {
+		fmt.Fprintf(color.Output, "::%s file=%s,line=%d,title=%s::%s\n",
+			workflowCommandFor(todo.Type),
+			escapeWorkflowProperty(todo.Filename),
+			todo.Line,
+			escapeWorkflowProperty(todo.Type),
+			escapeWorkflowMessage(todo.Comment),
+		)
+	}
+}
+
+func workflowCommandFor(todoType string) string {
+	switch strings.ToUpper(todoType) {
+	case "FIXME", "HACK", "XXX", "BUG":
+		return "warning"
+	default:
+		return "notice"
+	}
+}
+
+func escapeWorkflowMessage(s string) string {
+	s = strings.ReplaceAll(s, "%", "%25")
+	s = strings.ReplaceAll(s, "\r", "%0D")
+	s = strings.ReplaceAll(s, "\n", "%0A")
+	return s
+}
+
+func escapeWorkflowProperty(s string) string {
+	s = escapeWorkflowMessage(s)
+	s = strings.ReplaceAll(s, ":", "%3A")
+	s = strings.ReplaceAll(s, ",", "%2C")
+	return s
+}

--- a/internal/output/workflow_test.go
+++ b/internal/output/workflow_test.go
@@ -1,0 +1,103 @@
+package output
+
+import (
+	"testing"
+
+	"github.com/Suree33/gh-pr-todo/pkg/types"
+)
+
+func TestPrintWorkflowCommands(t *testing.T) {
+	todos := []types.TODO{
+		{Filename: "a.go", Line: 5, Comment: "// TODO: a", Type: "TODO"},
+		{Filename: "b.go", Line: 20, Comment: "// FIXME: b", Type: "FIXME"},
+		{Filename: "c.go", Line: 7, Comment: "// HACK: c", Type: "HACK"},
+		{Filename: "d.go", Line: 9, Comment: "// XXX: d", Type: "XXX"},
+		{Filename: "e.go", Line: 11, Comment: "// BUG: e", Type: "BUG"},
+		{Filename: "f.go", Line: 1, Comment: "// NOTE: f", Type: "NOTE"},
+	}
+
+	want := "::notice file=a.go,line=5,title=TODO::// TODO: a\n" +
+		"::warning file=b.go,line=20,title=FIXME::// FIXME: b\n" +
+		"::warning file=c.go,line=7,title=HACK::// HACK: c\n" +
+		"::warning file=d.go,line=9,title=XXX::// XXX: d\n" +
+		"::warning file=e.go,line=11,title=BUG::// BUG: e\n" +
+		"::notice file=f.go,line=1,title=NOTE::// NOTE: f\n"
+
+	got := captureOutput(t, func() {
+		PrintWorkflowCommands(todos)
+	})
+	if got != want {
+		t.Fatalf("PrintWorkflowCommands() output mismatch\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
+func TestPrintWorkflowCommandsEmpty(t *testing.T) {
+	got := captureOutput(t, func() {
+		PrintWorkflowCommands(nil)
+	})
+	if got != "" {
+		t.Fatalf("PrintWorkflowCommands(nil) = %q, want empty", got)
+	}
+}
+
+func TestEscapeWorkflowMessage(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"plain", "plain"},
+		{"100% sure", "100%25 sure"},
+		{"a\nb", "a%0Ab"},
+		{"a\rb", "a%0Db"},
+		{"a%b\nc\rd", "a%25b%0Ac%0Dd"},
+		{"a:b,c", "a:b,c"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			if got := escapeWorkflowMessage(tt.in); got != tt.want {
+				t.Fatalf("escapeWorkflowMessage(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEscapeWorkflowProperty(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"plain", "plain"},
+		{"a:b", "a%3Ab"},
+		{"a,b", "a%2Cb"},
+		{"a%b\nc:d,e\rf", "a%25b%0Ac%3Ad%2Ce%0Df"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			if got := escapeWorkflowProperty(tt.in); got != tt.want {
+				t.Fatalf("escapeWorkflowProperty(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWorkflowCommandFor(t *testing.T) {
+	tests := []struct {
+		todoType string
+		want     string
+	}{
+		{"TODO", "notice"},
+		{"todo", "notice"},
+		{"NOTE", "notice"},
+		{"FIXME", "warning"},
+		{"fixme", "warning"},
+		{"HACK", "warning"},
+		{"XXX", "warning"},
+		{"BUG", "warning"},
+		{"unknown", "notice"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.todoType, func(t *testing.T) {
+			if got := workflowCommandFor(tt.todoType); got != tt.want {
+				t.Fatalf("workflowCommandFor(%q) = %q, want %q", tt.todoType, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/output/workflow_test.go
+++ b/internal/output/workflow_test.go
@@ -31,6 +31,27 @@ func TestPrintWorkflowCommands(t *testing.T) {
 	}
 }
 
+func TestPrintWorkflowCommandsAppliesEscaping(t *testing.T) {
+	todos := []types.TODO{
+		{
+			Filename: "weird:dir,name/with%pct.go",
+			Line:     42,
+			Comment:  "// TODO: 100% rate\r\nrest of comment",
+			Type:     "fix,me",
+		},
+	}
+
+	want := "::notice file=weird%3Adir%2Cname/with%25pct.go,line=42,title=fix%2Cme::" +
+		"// TODO: 100%25 rate%0D%0Arest of comment\n"
+
+	got := captureOutput(t, func() {
+		PrintWorkflowCommands(todos)
+	})
+	if got != want {
+		t.Fatalf("PrintWorkflowCommands escaping mismatch\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
 func TestPrintWorkflowCommandsEmpty(t *testing.T) {
 	got := captureOutput(t, func() {
 		PrintWorkflowCommands(nil)

--- a/main.go
+++ b/main.go
@@ -124,7 +124,8 @@ func printUsage() {
 	fmt.Fprintf(color.Output, "%s\n", output.Bold("ENVIRONMENT"))
 	fmt.Fprintf(color.Output, "  %s\n", "CI               When truthy (e.g. \"1\", \"true\"), exits non-zero if any TODO is found.")
 	fmt.Fprintf(color.Output, "  %s\n", "                 Override with --no-ci-fail.")
-	fmt.Fprintf(color.Output, "  %s\n\n", "GITHUB_ACTIONS   When truthy, also emits GitHub Actions workflow commands so each TODO appears as an annotation.")
+	fmt.Fprintf(color.Output, "  %s\n", "GITHUB_ACTIONS   When truthy, emits GitHub Actions workflow commands so each TODO appears as an annotation.")
+	fmt.Fprintf(color.Output, "  %s\n\n", "                 Only emitted in the default mode; --count and --name-only stay machine-readable.")
 }
 
 func runMain(fetcher ghclient.PRFetcher, repo, pr string, groupBy types.GroupBy, gha bool) (int, error) {

--- a/main.go
+++ b/main.go
@@ -57,17 +57,18 @@ func main() {
 	}
 
 	fetcher := ghclient.NewClient()
+	gha := isGitHubActions()
 	var (
 		err   error
 		count int
 	)
 	switch {
 	case nameOnly:
-		count, err = runNameOnly(fetcher, repo, pr)
+		count, err = runNameOnly(fetcher, repo, pr, gha)
 	case isCount:
-		count, err = runCount(fetcher, repo, pr)
+		count, err = runCount(fetcher, repo, pr, gha)
 	default:
-		count, err = runMain(fetcher, repo, pr, groupBy)
+		count, err = runMain(fetcher, repo, pr, groupBy, gha)
 	}
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -87,6 +88,12 @@ func exitCode(err error, count int, ci, noCIFail bool) int {
 
 func isCI() bool {
 	v := strings.TrimSpace(os.Getenv("CI"))
+	ok, err := strconv.ParseBool(v)
+	return err == nil && ok
+}
+
+func isGitHubActions() bool {
+	v := strings.TrimSpace(os.Getenv("GITHUB_ACTIONS"))
 	ok, err := strconv.ParseBool(v)
 	return err == nil && ok
 }
@@ -115,11 +122,12 @@ func printUsage() {
 	})
 	fmt.Fprintln(color.Output)
 	fmt.Fprintf(color.Output, "%s\n", output.Bold("ENVIRONMENT"))
-	fmt.Fprintf(color.Output, "  %s\n", "CI  When truthy (e.g. \"1\", \"true\"), exits non-zero if any TODO is found.")
-	fmt.Fprintf(color.Output, "  %s\n\n", "    Override with --no-ci-fail.")
+	fmt.Fprintf(color.Output, "  %s\n", "CI               When truthy (e.g. \"1\", \"true\"), exits non-zero if any TODO is found.")
+	fmt.Fprintf(color.Output, "  %s\n", "                 Override with --no-ci-fail.")
+	fmt.Fprintf(color.Output, "  %s\n\n", "GITHUB_ACTIONS   When truthy, also emits GitHub Actions workflow commands so each TODO appears as an annotation.")
 }
 
-func runMain(fetcher ghclient.PRFetcher, repo, pr string, groupBy types.GroupBy) (int, error) {
+func runMain(fetcher ghclient.PRFetcher, repo, pr string, groupBy types.GroupBy, gha bool) (int, error) {
 	sp := spinner.New(spinner.CharSets[14], 40*time.Millisecond)
 	fetchingMsg := " Fetching PR diff..."
 	sp.Suffix = fetchingMsg
@@ -141,23 +149,32 @@ func runMain(fetcher ghclient.PRFetcher, repo, pr string, groupBy types.GroupBy)
 
 	fmt.Fprintf(color.Output, output.Bold("\nFound %d TODO comment(s)\n\n"), len(todos))
 	output.PrintTODOs(todos, groupBy)
+	if gha {
+		output.PrintWorkflowCommands(todos)
+	}
 	return len(todos), nil
 }
 
-func runCount(fetcher ghclient.PRFetcher, repo, pr string) (int, error) {
+func runCount(fetcher ghclient.PRFetcher, repo, pr string, gha bool) (int, error) {
 	todos, err := ghclient.CollectTODOs(fetcher, repo, pr)
 	if err != nil {
 		return 0, err
 	}
 	output.PrintCount(todos)
+	if gha {
+		output.PrintWorkflowCommands(todos)
+	}
 	return len(todos), nil
 }
 
-func runNameOnly(fetcher ghclient.PRFetcher, repo, pr string) (int, error) {
+func runNameOnly(fetcher ghclient.PRFetcher, repo, pr string, gha bool) (int, error) {
 	todos, err := ghclient.CollectTODOs(fetcher, repo, pr)
 	if err != nil {
 		return 0, err
 	}
 	output.PrintFileNames(todos)
+	if gha {
+		output.PrintWorkflowCommands(todos)
+	}
 	return len(todos), nil
 }

--- a/main.go
+++ b/main.go
@@ -64,9 +64,9 @@ func main() {
 	)
 	switch {
 	case nameOnly:
-		count, err = runNameOnly(fetcher, repo, pr, gha)
+		count, err = runNameOnly(fetcher, repo, pr)
 	case isCount:
-		count, err = runCount(fetcher, repo, pr, gha)
+		count, err = runCount(fetcher, repo, pr)
 	default:
 		count, err = runMain(fetcher, repo, pr, groupBy, gha)
 	}
@@ -128,13 +128,18 @@ func printUsage() {
 }
 
 func runMain(fetcher ghclient.PRFetcher, repo, pr string, groupBy types.GroupBy, gha bool) (int, error) {
-	sp := spinner.New(spinner.CharSets[14], 40*time.Millisecond)
 	fetchingMsg := " Fetching PR diff..."
-	sp.Suffix = fetchingMsg
-	sp.Start()
+	var sp *spinner.Spinner
+	if !gha {
+		sp = spinner.New(spinner.CharSets[14], 40*time.Millisecond)
+		sp.Suffix = fetchingMsg
+		sp.Start()
+	}
 
 	todos, err := ghclient.CollectTODOs(fetcher, repo, pr)
-	sp.Stop()
+	if sp != nil {
+		sp.Stop()
+	}
 
 	if err != nil {
 		fmt.Fprintf(color.Output, "%s%s\n", output.Red("✗"), fetchingMsg)
@@ -155,26 +160,20 @@ func runMain(fetcher ghclient.PRFetcher, repo, pr string, groupBy types.GroupBy,
 	return len(todos), nil
 }
 
-func runCount(fetcher ghclient.PRFetcher, repo, pr string, gha bool) (int, error) {
+func runCount(fetcher ghclient.PRFetcher, repo, pr string) (int, error) {
 	todos, err := ghclient.CollectTODOs(fetcher, repo, pr)
 	if err != nil {
 		return 0, err
 	}
 	output.PrintCount(todos)
-	if gha {
-		output.PrintWorkflowCommands(todos)
-	}
 	return len(todos), nil
 }
 
-func runNameOnly(fetcher ghclient.PRFetcher, repo, pr string, gha bool) (int, error) {
+func runNameOnly(fetcher ghclient.PRFetcher, repo, pr string) (int, error) {
 	todos, err := ghclient.CollectTODOs(fetcher, repo, pr)
 	if err != nil {
 		return 0, err
 	}
 	output.PrintFileNames(todos)
-	if gha {
-		output.PrintWorkflowCommands(todos)
-	}
 	return len(todos), nil
 }

--- a/main.go
+++ b/main.go
@@ -87,6 +87,9 @@ func exitCode(err error, count int, ci, noCIFail bool) int {
 }
 
 func isCI() bool {
+	if isGitHubActions() {
+		return true
+	}
 	v := strings.TrimSpace(os.Getenv("CI"))
 	ok, err := strconv.ParseBool(v)
 	return err == nil && ok
@@ -125,7 +128,8 @@ func printUsage() {
 	fmt.Fprintf(color.Output, "  %s\n", "CI               When truthy (e.g. \"1\", \"true\"), exits non-zero if any TODO is found.")
 	fmt.Fprintf(color.Output, "  %s\n", "                 Override with --no-ci-fail.")
 	fmt.Fprintf(color.Output, "  %s\n", "GITHUB_ACTIONS   When truthy, emits GitHub Actions workflow commands so each TODO appears as an annotation.")
-	fmt.Fprintf(color.Output, "  %s\n\n", "                 Only emitted in the default mode; --count and --name-only stay machine-readable.")
+	fmt.Fprintf(color.Output, "  %s\n", "                 Only emitted in the default mode; --count and --name-only stay machine-readable.")
+	fmt.Fprintf(color.Output, "  %s\n\n", "                 Implies CI=true, so --no-ci-fail is required to suppress the non-zero exit.")
 }
 
 func runMain(fetcher ghclient.PRFetcher, repo, pr string, groupBy types.GroupBy, gha bool) (int, error) {

--- a/main_test.go
+++ b/main_test.go
@@ -193,7 +193,7 @@ func TestRunMain(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var gotErr error
 			out, stdout, gotStderr := captureAll(t, func() {
-				_, gotErr = runMain(tt.fetcher, "o/r", "1", tt.groupBy)
+				_, gotErr = runMain(tt.fetcher, "o/r", "1", tt.groupBy, false)
 			})
 
 			if tt.wantErr != "" {
@@ -239,7 +239,7 @@ func TestRunCount(t *testing.T) {
 		fetcher := &stubFetcher{diffErr: errors.New("boom")}
 		var err error
 		out, stdout, stderr := captureAll(t, func() {
-			_, err = runCount(fetcher, "", "")
+			_, err = runCount(fetcher, "", "", false)
 		})
 		if err == nil || err.Error() != "boom" {
 			t.Fatalf("runCount() error = %v, expected boom", err)
@@ -257,7 +257,7 @@ func TestRunCount(t *testing.T) {
 		}
 		var err error
 		out, stdout, stderr := captureAll(t, func() {
-			_, err = runCount(fetcher, "o/r", "1")
+			_, err = runCount(fetcher, "o/r", "1", false)
 		})
 		if err != nil {
 			t.Fatalf("runCount() unexpected error = %v", err)
@@ -277,7 +277,7 @@ func TestRunNameOnly(t *testing.T) {
 		fetcher := &stubFetcher{diffErr: errors.New("boom")}
 		var err error
 		out, stdout, stderr := captureAll(t, func() {
-			_, err = runNameOnly(fetcher, "", "")
+			_, err = runNameOnly(fetcher, "", "", false)
 		})
 		if err == nil || err.Error() != "boom" {
 			t.Fatalf("runNameOnly() error = %v, expected boom", err)
@@ -295,7 +295,7 @@ func TestRunNameOnly(t *testing.T) {
 		}
 		var err error
 		out, stdout, stderr := captureAll(t, func() {
-			_, err = runNameOnly(fetcher, "o/r", "1")
+			_, err = runNameOnly(fetcher, "o/r", "1", false)
 		})
 		if err != nil {
 			t.Fatalf("runNameOnly() unexpected error = %v", err)
@@ -313,7 +313,7 @@ func TestRunNameOnly(t *testing.T) {
 		fetcher := &stubFetcher{diff: "", files: map[string][]byte{}}
 		var err error
 		out, stdout, stderr := captureAll(t, func() {
-			_, err = runNameOnly(fetcher, "", "")
+			_, err = runNameOnly(fetcher, "", "", false)
 		})
 		if err != nil {
 			t.Fatalf("runNameOnly() unexpected error = %v", err)
@@ -362,6 +362,83 @@ func TestIsCI(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestIsGitHubActions(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		set   bool
+		want  bool
+	}{
+		{name: "unset returns false", set: false, want: false},
+		{name: "empty returns false", value: "", set: true, want: false},
+		{name: "GITHUB_ACTIONS=true returns true", value: "true", set: true, want: true},
+		{name: "GITHUB_ACTIONS=1 returns true", value: "1", set: true, want: true},
+		{name: "GITHUB_ACTIONS=false returns false", value: "false", set: true, want: false},
+		{name: "GITHUB_ACTIONS=0 returns false", value: "0", set: true, want: false},
+		{name: "GITHUB_ACTIONS surrounded by whitespace returns true", value: "  true  ", set: true, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.set {
+				t.Setenv("GITHUB_ACTIONS", tt.value)
+			} else {
+				if err := os.Unsetenv("GITHUB_ACTIONS"); err != nil {
+					t.Fatalf("os.Unsetenv() error = %v", err)
+				}
+				t.Cleanup(func() { _ = os.Unsetenv("GITHUB_ACTIONS") })
+			}
+			if got := isGitHubActions(); got != tt.want {
+				t.Fatalf("isGitHubActions() = %v, expected %v (GITHUB_ACTIONS set=%v value=%q)", got, tt.want, tt.set, tt.value)
+			}
+		})
+	}
+}
+
+func TestRunFunctionsEmitWorkflowCommands(t *testing.T) {
+	fetcher := &stubFetcher{
+		diff:  sampleDiff,
+		files: map[string][]byte{"foo.go": []byte("package foo\n// TODO: add bar\n")},
+	}
+	wantLine := "::notice file=foo.go,line=2,title=TODO::// TODO: add bar"
+
+	t.Run("runMain emits when gha=true", func(t *testing.T) {
+		out, _, _ := captureAll(t, func() {
+			_, _ = runMain(fetcher, "o/r", "1", types.GroupByNone, true)
+		})
+		if !strings.Contains(out, wantLine) {
+			t.Fatalf("runMain(gha=true) output = %q, expected to contain %q", out, wantLine)
+		}
+	})
+
+	t.Run("runMain does not emit when gha=false", func(t *testing.T) {
+		out, _, _ := captureAll(t, func() {
+			_, _ = runMain(fetcher, "o/r", "1", types.GroupByNone, false)
+		})
+		if strings.Contains(out, "::notice ") || strings.Contains(out, "::warning ") {
+			t.Fatalf("runMain(gha=false) unexpectedly emitted workflow command: %q", out)
+		}
+	})
+
+	t.Run("runCount emits when gha=true", func(t *testing.T) {
+		out, _, _ := captureAll(t, func() {
+			_, _ = runCount(fetcher, "o/r", "1", true)
+		})
+		if !strings.Contains(out, wantLine) {
+			t.Fatalf("runCount(gha=true) output = %q, expected to contain %q", out, wantLine)
+		}
+	})
+
+	t.Run("runNameOnly emits when gha=true", func(t *testing.T) {
+		out, _, _ := captureAll(t, func() {
+			_, _ = runNameOnly(fetcher, "o/r", "1", true)
+		})
+		if !strings.Contains(out, wantLine) {
+			t.Fatalf("runNameOnly(gha=true) output = %q, expected to contain %q", out, wantLine)
+		}
+	})
 }
 
 func TestExitCode(t *testing.T) {
@@ -436,7 +513,7 @@ index 0000000..1111111 100644
 			var gotCount int
 			var gotErr error
 			_, _, _ = captureAll(t, func() {
-				gotCount, gotErr = runMain(tt.fetcher, "o/r", "1", types.GroupByNone)
+				gotCount, gotErr = runMain(tt.fetcher, "o/r", "1", types.GroupByNone, false)
 			})
 			if gotErr != nil {
 				t.Fatalf("runMain() unexpected error = %v", gotErr)
@@ -450,7 +527,7 @@ index 0000000..1111111 100644
 			var gotCount int
 			var gotErr error
 			_, _, _ = captureAll(t, func() {
-				gotCount, gotErr = runCount(tt.fetcher, "o/r", "1")
+				gotCount, gotErr = runCount(tt.fetcher, "o/r", "1", false)
 			})
 			if gotErr != nil {
 				t.Fatalf("runCount() unexpected error = %v", gotErr)
@@ -464,7 +541,7 @@ index 0000000..1111111 100644
 			var gotCount int
 			var gotErr error
 			_, _, _ = captureAll(t, func() {
-				gotCount, gotErr = runNameOnly(tt.fetcher, "o/r", "1")
+				gotCount, gotErr = runNameOnly(tt.fetcher, "o/r", "1", false)
 			})
 			if gotErr != nil {
 				t.Fatalf("runNameOnly() unexpected error = %v", gotErr)
@@ -482,7 +559,7 @@ func TestRunFunctionsReturnZeroCountOnError(t *testing.T) {
 		var gotCount int
 		var gotErr error
 		_, _, _ = captureAll(t, func() {
-			gotCount, gotErr = runMain(fetcher, "", "", types.GroupByNone)
+			gotCount, gotErr = runMain(fetcher, "", "", types.GroupByNone, false)
 		})
 		if gotErr == nil {
 			t.Fatalf("runMain() expected error, got nil")
@@ -497,7 +574,7 @@ func TestRunFunctionsReturnZeroCountOnError(t *testing.T) {
 		var gotCount int
 		var gotErr error
 		_, _, _ = captureAll(t, func() {
-			gotCount, gotErr = runCount(fetcher, "", "")
+			gotCount, gotErr = runCount(fetcher, "", "", false)
 		})
 		if gotErr == nil {
 			t.Fatalf("runCount() expected error, got nil")
@@ -512,7 +589,7 @@ func TestRunFunctionsReturnZeroCountOnError(t *testing.T) {
 		var gotCount int
 		var gotErr error
 		_, _, _ = captureAll(t, func() {
-			gotCount, gotErr = runNameOnly(fetcher, "", "")
+			gotCount, gotErr = runNameOnly(fetcher, "", "", false)
 		})
 		if gotErr == nil {
 			t.Fatalf("runNameOnly() expected error, got nil")
@@ -570,6 +647,7 @@ func TestPrintUsage(t *testing.T) {
 		"--no-ci-fail",
 		"ENVIRONMENT",
 		"CI",
+		"GITHUB_ACTIONS",
 	}
 	for _, want := range wantContain {
 		if !strings.Contains(out, want) {

--- a/main_test.go
+++ b/main_test.go
@@ -349,6 +349,7 @@ func TestIsCI(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("GITHUB_ACTIONS", "")
 			if tt.set {
 				t.Setenv("CI", tt.value)
 			} else {
@@ -359,6 +360,38 @@ func TestIsCI(t *testing.T) {
 			}
 			if got := isCI(); got != tt.want {
 				t.Fatalf("isCI() = %v, expected %v (CI set=%v value=%q)", got, tt.want, tt.set, tt.value)
+			}
+		})
+	}
+}
+
+func TestIsCIPromotedByGitHubActions(t *testing.T) {
+	tests := []struct {
+		name        string
+		ci          string
+		ciSet       bool
+		githubValue string
+		want        bool
+	}{
+		{name: "GITHUB_ACTIONS=true forces CI true even when CI unset", ciSet: false, githubValue: "true", want: true},
+		{name: "GITHUB_ACTIONS=true forces CI true even when CI=false", ci: "false", ciSet: true, githubValue: "true", want: true},
+		{name: "GITHUB_ACTIONS=1 forces CI true even when CI=0", ci: "0", ciSet: true, githubValue: "1", want: true},
+		{name: "GITHUB_ACTIONS=false does not force CI true", ci: "false", ciSet: true, githubValue: "false", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.ciSet {
+				t.Setenv("CI", tt.ci)
+			} else {
+				if err := os.Unsetenv("CI"); err != nil {
+					t.Fatalf("os.Unsetenv() error = %v", err)
+				}
+				t.Cleanup(func() { _ = os.Unsetenv("CI") })
+			}
+			t.Setenv("GITHUB_ACTIONS", tt.githubValue)
+			if got := isCI(); got != tt.want {
+				t.Fatalf("isCI() = %v, expected %v (CI set=%v value=%q, GITHUB_ACTIONS=%q)", got, tt.want, tt.ciSet, tt.ci, tt.githubValue)
 			}
 		})
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -239,7 +239,7 @@ func TestRunCount(t *testing.T) {
 		fetcher := &stubFetcher{diffErr: errors.New("boom")}
 		var err error
 		out, stdout, stderr := captureAll(t, func() {
-			_, err = runCount(fetcher, "", "", false)
+			_, err = runCount(fetcher, "", "")
 		})
 		if err == nil || err.Error() != "boom" {
 			t.Fatalf("runCount() error = %v, expected boom", err)
@@ -257,7 +257,7 @@ func TestRunCount(t *testing.T) {
 		}
 		var err error
 		out, stdout, stderr := captureAll(t, func() {
-			_, err = runCount(fetcher, "o/r", "1", false)
+			_, err = runCount(fetcher, "o/r", "1")
 		})
 		if err != nil {
 			t.Fatalf("runCount() unexpected error = %v", err)
@@ -277,7 +277,7 @@ func TestRunNameOnly(t *testing.T) {
 		fetcher := &stubFetcher{diffErr: errors.New("boom")}
 		var err error
 		out, stdout, stderr := captureAll(t, func() {
-			_, err = runNameOnly(fetcher, "", "", false)
+			_, err = runNameOnly(fetcher, "", "")
 		})
 		if err == nil || err.Error() != "boom" {
 			t.Fatalf("runNameOnly() error = %v, expected boom", err)
@@ -295,7 +295,7 @@ func TestRunNameOnly(t *testing.T) {
 		}
 		var err error
 		out, stdout, stderr := captureAll(t, func() {
-			_, err = runNameOnly(fetcher, "o/r", "1", false)
+			_, err = runNameOnly(fetcher, "o/r", "1")
 		})
 		if err != nil {
 			t.Fatalf("runNameOnly() unexpected error = %v", err)
@@ -313,7 +313,7 @@ func TestRunNameOnly(t *testing.T) {
 		fetcher := &stubFetcher{diff: "", files: map[string][]byte{}}
 		var err error
 		out, stdout, stderr := captureAll(t, func() {
-			_, err = runNameOnly(fetcher, "", "", false)
+			_, err = runNameOnly(fetcher, "", "")
 		})
 		if err != nil {
 			t.Fatalf("runNameOnly() unexpected error = %v", err)
@@ -422,21 +422,23 @@ func TestRunFunctionsEmitWorkflowCommands(t *testing.T) {
 		}
 	})
 
-	t.Run("runCount emits when gha=true", func(t *testing.T) {
+	t.Run("runCount stdout stays plain", func(t *testing.T) {
+		t.Setenv("GITHUB_ACTIONS", "true")
 		out, _, _ := captureAll(t, func() {
-			_, _ = runCount(fetcher, "o/r", "1", true)
+			_, _ = runCount(fetcher, "o/r", "1")
 		})
-		if !strings.Contains(out, wantLine) {
-			t.Fatalf("runCount(gha=true) output = %q, expected to contain %q", out, wantLine)
+		if strings.Contains(out, "::notice") || strings.Contains(out, "::warning") {
+			t.Fatalf("runCount must not emit workflow commands; got %q", out)
 		}
 	})
 
-	t.Run("runNameOnly emits when gha=true", func(t *testing.T) {
+	t.Run("runNameOnly stdout stays plain", func(t *testing.T) {
+		t.Setenv("GITHUB_ACTIONS", "true")
 		out, _, _ := captureAll(t, func() {
-			_, _ = runNameOnly(fetcher, "o/r", "1", true)
+			_, _ = runNameOnly(fetcher, "o/r", "1")
 		})
-		if !strings.Contains(out, wantLine) {
-			t.Fatalf("runNameOnly(gha=true) output = %q, expected to contain %q", out, wantLine)
+		if strings.Contains(out, "::notice") || strings.Contains(out, "::warning") {
+			t.Fatalf("runNameOnly must not emit workflow commands; got %q", out)
 		}
 	})
 }
@@ -527,7 +529,7 @@ index 0000000..1111111 100644
 			var gotCount int
 			var gotErr error
 			_, _, _ = captureAll(t, func() {
-				gotCount, gotErr = runCount(tt.fetcher, "o/r", "1", false)
+				gotCount, gotErr = runCount(tt.fetcher, "o/r", "1")
 			})
 			if gotErr != nil {
 				t.Fatalf("runCount() unexpected error = %v", gotErr)
@@ -541,7 +543,7 @@ index 0000000..1111111 100644
 			var gotCount int
 			var gotErr error
 			_, _, _ = captureAll(t, func() {
-				gotCount, gotErr = runNameOnly(tt.fetcher, "o/r", "1", false)
+				gotCount, gotErr = runNameOnly(tt.fetcher, "o/r", "1")
 			})
 			if gotErr != nil {
 				t.Fatalf("runNameOnly() unexpected error = %v", gotErr)
@@ -574,7 +576,7 @@ func TestRunFunctionsReturnZeroCountOnError(t *testing.T) {
 		var gotCount int
 		var gotErr error
 		_, _, _ = captureAll(t, func() {
-			gotCount, gotErr = runCount(fetcher, "", "", false)
+			gotCount, gotErr = runCount(fetcher, "", "")
 		})
 		if gotErr == nil {
 			t.Fatalf("runCount() expected error, got nil")
@@ -589,7 +591,7 @@ func TestRunFunctionsReturnZeroCountOnError(t *testing.T) {
 		var gotCount int
 		var gotErr error
 		_, _, _ = captureAll(t, func() {
-			gotCount, gotErr = runNameOnly(fetcher, "", "", false)
+			gotCount, gotErr = runNameOnly(fetcher, "", "")
 		})
 		if gotErr == nil {
 			t.Fatalf("runNameOnly() expected error, got nil")


### PR DESCRIPTION
## Summary

Emit [GitHub Actions workflow commands](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands) when `GITHUB_ACTIONS=true`, so each TODO surfaces as an inline annotation on the workflow run and pull request.

### Behavior

- `TODO`, `NOTE` → `::notice` annotations
- `FIXME`, `HACK`, `XXX`, `BUG` → `::warning` annotations
- Each annotation carries `file`, `line`, and `title` (the TODO keyword)
- Message and property values are escaped per the workflow command spec (`%`, `\r`, `\n`; properties additionally escape `:`, `,`)
- Workflow commands are emitted **only in the default mode**; `--count` and `--name-only` keep their plain machine-readable output so `count=$(gh pr-todo --count)` style pipelines stay reliable on Actions
- The spinner is suppressed under `GITHUB_ACTIONS=true` to keep Actions logs clean
- `GITHUB_ACTIONS=true` is treated as `CI=true`, so the existing non-zero exit on TODOs works on the runner without users having to also set `CI` (override with `--no-ci-fail`)

### Example

```
::notice file=src/api/users.go,line=42,title=TODO::// TODO: Add input validation for email format
::warning file=components/Header.tsx,line=15,title=FIXME::// FIXME: Memory leak in event listener cleanup
```

### Tests

- `internal/output/workflow_test.go` — unit tests for level mapping, message/property escaping, and an end-to-end escaping case
- `main_test.go` — `isGitHubActions` env detection, default-mode-only emission contract, `isCI` promotion via `GITHUB_ACTIONS`
- `--help` and README are updated to document the new behavior

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/suree33/gh-pr-todo/pull/72" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->