### PR TITLE
docs(readme): align usage with repo flag behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 [![Downloads](https://img.shields.io/github/downloads/Suree33/gh-pr-todo/total?label=Downloads&color=blue)](https://github.com/Suree33/gh-pr-todo/releases)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/Suree33/gh-pr-todo)
 
-A GitHub CLI extension that extracts TODO comments from pull request diffs, helping you track action items and reminders in your code changes.
+A GitHub CLI extension that extracts TODO-style comments from pull request diffs, helping you track action items and reminders in your code changes.
 
 ## Features
 
-- **Syntax-Aware Detection**: Uses Tree-sitter for accurate TODO detection in supported languages, with regex fallback for others
+- **Syntax-Aware Detection**: Uses Tree-sitter for accurate TODO-style comment detection in supported languages, with regex fallback for others
 - **Beautiful Output**: Colorized terminal output with loading indicators
 - **Multiple Formats**: Supports various comment styles (`//`, `#`, `<!--`, `;`, `/*`)
 - **Fast**: Efficient diff parsing with GitHub CLI integration
@@ -35,12 +35,9 @@ gh pr-todo
 
 ### Advanced Usage
 
-You can specify different repositories, PR numbers, URLs, or branches just like `gh pr diff`:
+You can specify PR numbers, URLs, or branches, and you can target another repository with `-R/--repo`:
 
 ```bash
-# Specify a different repository
-gh pr-todo -R owner/repo
-
 # Specify a specific PR number
 gh pr-todo 123
 
@@ -52,6 +49,9 @@ gh pr-todo https://github.com/owner/repo/pull/789
 
 # Specify a branch
 gh pr-todo feature-branch
+
+# Specify a branch from a different repository
+gh pr-todo feature-branch -R owner/repo
 
 # Display only names of the files containing TODO comments
 gh pr-todo --name-only
@@ -66,10 +66,11 @@ gh pr-todo --group-by file
 ### Command Options
 
 - `[<number> | <url> | <branch>]`: Specify a PR by number, URL, or branch name
-- `-R, --repo [HOST/]OWNER/REPO`: Select another repository using the [HOST/]OWNER/REPO format
-- `--group-by`: Group TODO comments by file or type
+- `-R, --repo [HOST/]OWNER/REPO`: Select another repository using the [HOST/]OWNER/REPO format (requires a PR number, URL, or branch argument)
+- `--group-by`: Group TODO comments by `file` or `type`
 - `--name-only`: Display only names of the files containing TODO comments
 - `-c, --count`: Display only the number of TODO comments
+- `-h, --help`: Display help information
 - `--no-ci-fail`: Disable non-zero exit when TODOs are found in CI (see below)
 
 ### CI Mode


### PR DESCRIPTION
## Summary

- align the README's --repo examples and option text with the current CLI behavior
- clarify that the tool detects TODO-style comments and document the help flag

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/suree33/gh-pr-todo/pull/74" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->