### PR TITLE
fix(todo-type): fail only on warning-level TODOs

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,11 +71,11 @@ gh pr-todo --group-by file
 - `--name-only`: Display only names of the files containing TODO comments
 - `-c, --count`: Display only the number of TODO comments
 - `-h, --help`: Display help information
-- `--no-ci-fail`: Disable non-zero exit when TODOs are found in CI (see below)
+- `--no-ci-fail`: Disable non-zero exit when warning-level TODOs are found in CI (see below)
 
 ### CI Mode
 
-When the `CI` environment variable is set to a truthy value (e.g. `1`, `true`, parsed via Go's `strconv.ParseBool`), `gh pr-todo` exits with status `1` if any TODO-style comments are detected in the PR diff. This makes it easy to fail a CI job when new TODOs slip into a pull request. `GITHUB_ACTIONS=true` (set automatically by the GitHub Actions runner) is treated as `CI=true` even when the `CI` variable is missing or falsy.
+When the `CI` environment variable is set to a truthy value (e.g. `1`, `true`, parsed via Go's `strconv.ParseBool`), `gh pr-todo` exits with status `1` if any warning-level TODO-style comments are detected in the PR diff. This matches the GitHub Actions annotation behavior: `FIXME`, `HACK`, `XXX`, and `BUG` fail CI, while notice-only `TODO` and `NOTE` comments do not. `GITHUB_ACTIONS=true` (set automatically by the GitHub Actions runner) is treated as `CI=true` even when the `CI` variable is missing or falsy.
 
 ```yaml
 # GitHub Actions example — CI=true is set automatically

--- a/internal/output/workflow.go
+++ b/internal/output/workflow.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Suree33/gh-pr-todo/internal/todotype"
 	"github.com/Suree33/gh-pr-todo/pkg/types"
 	"github.com/fatih/color"
 )
@@ -25,12 +26,10 @@ func PrintWorkflowCommands(todos []types.TODO) {
 }
 
 func workflowCommandFor(todoType string) string {
-	switch strings.ToUpper(todoType) {
-	case "FIXME", "HACK", "XXX", "BUG":
+	if todotype.IsWarning(todoType) {
 		return "warning"
-	default:
-		return "notice"
 	}
+	return "notice"
 }
 
 func escapeWorkflowMessage(s string) string {

--- a/internal/todotype/todotype.go
+++ b/internal/todotype/todotype.go
@@ -1,0 +1,28 @@
+package todotype
+
+import (
+	"strings"
+
+	"github.com/Suree33/gh-pr-todo/pkg/types"
+)
+
+// IsWarning reports whether a TODO-style marker should be treated as a
+// GitHub Actions warning annotation.
+func IsWarning(todoType string) bool {
+	switch strings.ToUpper(todoType) {
+	case "FIXME", "HACK", "XXX", "BUG":
+		return true
+	default:
+		return false
+	}
+}
+
+func CountWarnings(todos []types.TODO) int {
+	count := 0
+	for _, todo := range todos {
+		if IsWarning(todo.Type) {
+			count++
+		}
+	}
+	return count
+}

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 
 	ghclient "github.com/Suree33/gh-pr-todo/internal/github"
 	"github.com/Suree33/gh-pr-todo/internal/output"
+	"github.com/Suree33/gh-pr-todo/internal/todotype"
 	"github.com/Suree33/gh-pr-todo/pkg/types"
 	"github.com/briandowns/spinner"
 	"github.com/fatih/color"
@@ -28,7 +29,7 @@ func main() {
 	pflag.BoolVar(&nameOnly, "name-only", false, "Display only names of the files containing TODO comments")
 	pflag.BoolVarP(&isCount, "count", "c", false, "Display only the number of TODO comments")
 	pflag.BoolVarP(&isHelp, "help", "h", false, "Display help information")
-	pflag.BoolVar(&noCIFail, "no-ci-fail", false, "Disable non-zero exit when TODOs are found in CI")
+	pflag.BoolVar(&noCIFail, "no-ci-fail", false, "Disable non-zero exit when warning-level TODOs are found in CI")
 	pflag.Var(&groupBy, "group-by", "Group TODO comments by: \"file\" or \"type\"")
 	pflag.Usage = printUsage
 	pflag.Parse()
@@ -59,28 +60,40 @@ func main() {
 	fetcher := ghclient.NewClient()
 	gha := isGitHubActions()
 	var (
-		err   error
-		count int
+		err    error
+		result runResult
 	)
 	switch {
 	case nameOnly:
-		count, err = runNameOnly(fetcher, repo, pr)
+		result, err = runNameOnly(fetcher, repo, pr)
 	case isCount:
-		count, err = runCount(fetcher, repo, pr)
+		result, err = runCount(fetcher, repo, pr)
 	default:
-		count, err = runMain(fetcher, repo, pr, groupBy, gha)
+		result, err = runMain(fetcher, repo, pr, groupBy, gha)
 	}
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 	}
-	os.Exit(exitCode(err, count, isCI(), noCIFail))
+	os.Exit(exitCode(err, result.ciFailCount, isCI(), noCIFail))
 }
 
-func exitCode(err error, count int, ci, noCIFail bool) int {
+type runResult struct {
+	totalCount  int
+	ciFailCount int
+}
+
+func newRunResult(todos []types.TODO) runResult {
+	return runResult{
+		totalCount:  len(todos),
+		ciFailCount: todotype.CountWarnings(todos),
+	}
+}
+
+func exitCode(err error, ciFailCount int, ci, noCIFail bool) int {
 	if err != nil {
 		return 1
 	}
-	if ci && !noCIFail && count > 0 {
+	if ci && !noCIFail && ciFailCount > 0 {
 		return 1
 	}
 	return 0
@@ -125,14 +138,14 @@ func printUsage() {
 	})
 	fmt.Fprintln(color.Output)
 	fmt.Fprintf(color.Output, "%s\n", output.Bold("ENVIRONMENT"))
-	fmt.Fprintf(color.Output, "  %s\n", "CI               When truthy (e.g. \"1\", \"true\"), exits non-zero if any TODO is found.")
+	fmt.Fprintf(color.Output, "  %s\n", "CI               When truthy (e.g. \"1\", \"true\"), exits non-zero if warning-level TODOs are found.")
 	fmt.Fprintf(color.Output, "  %s\n", "                 Override with --no-ci-fail.")
 	fmt.Fprintf(color.Output, "  %s\n", "GITHUB_ACTIONS   When truthy, emits GitHub Actions workflow commands so each TODO appears as an annotation.")
 	fmt.Fprintf(color.Output, "  %s\n", "                 Only emitted in the default mode; --count and --name-only stay machine-readable.")
 	fmt.Fprintf(color.Output, "  %s\n\n", "                 Implies CI=true, so --no-ci-fail is required to suppress the non-zero exit.")
 }
 
-func runMain(fetcher ghclient.PRFetcher, repo, pr string, groupBy types.GroupBy, gha bool) (int, error) {
+func runMain(fetcher ghclient.PRFetcher, repo, pr string, groupBy types.GroupBy, gha bool) (runResult, error) {
 	fetchingMsg := " Fetching PR diff..."
 	var sp *spinner.Spinner
 	if !gha {
@@ -148,13 +161,13 @@ func runMain(fetcher ghclient.PRFetcher, repo, pr string, groupBy types.GroupBy,
 
 	if err != nil {
 		fmt.Fprintf(color.Output, "%s%s\n", output.Red("✗"), fetchingMsg)
-		return 0, err
+		return runResult{}, err
 	}
 	fmt.Fprintf(color.Output, "%s%s\n", output.Green("✔"), fetchingMsg)
 
 	if len(todos) == 0 {
 		fmt.Fprintf(color.Output, "\nNo TODO comments found in the diff.\n")
-		return 0, nil
+		return runResult{}, nil
 	}
 
 	fmt.Fprintf(color.Output, output.Bold("\nFound %d TODO comment(s)\n\n"), len(todos))
@@ -162,23 +175,23 @@ func runMain(fetcher ghclient.PRFetcher, repo, pr string, groupBy types.GroupBy,
 	if gha {
 		output.PrintWorkflowCommands(todos)
 	}
-	return len(todos), nil
+	return newRunResult(todos), nil
 }
 
-func runCount(fetcher ghclient.PRFetcher, repo, pr string) (int, error) {
+func runCount(fetcher ghclient.PRFetcher, repo, pr string) (runResult, error) {
 	todos, err := ghclient.CollectTODOs(fetcher, repo, pr)
 	if err != nil {
-		return 0, err
+		return runResult{}, err
 	}
 	output.PrintCount(todos)
-	return len(todos), nil
+	return newRunResult(todos), nil
 }
 
-func runNameOnly(fetcher ghclient.PRFetcher, repo, pr string) (int, error) {
+func runNameOnly(fetcher ghclient.PRFetcher, repo, pr string) (runResult, error) {
 	todos, err := ghclient.CollectTODOs(fetcher, repo, pr)
 	if err != nil {
-		return 0, err
+		return runResult{}, err
 	}
 	output.PrintFileNames(todos)
-	return len(todos), nil
+	return newRunResult(todos), nil
 }

--- a/main_test.go
+++ b/main_test.go
@@ -478,29 +478,59 @@ func TestRunFunctionsEmitWorkflowCommands(t *testing.T) {
 
 func TestExitCode(t *testing.T) {
 	tests := []struct {
-		name     string
-		err      error
-		count    int
-		ci       bool
-		noCIFail bool
-		want     int
+		name        string
+		err         error
+		ciFailCount int
+		ci          bool
+		noCIFail    bool
+		want        int
 	}{
 		{name: "error returns 1", err: errors.New("boom"), want: 1},
-		{name: "error in CI still 1", err: errors.New("boom"), ci: true, count: 5, want: 1},
-		{name: "no error no TODOs returns 0", want: 0},
-		{name: "no error TODOs not in CI returns 0", count: 3, want: 0},
-		{name: "no error TODOs in CI returns 1", count: 3, ci: true, want: 1},
-		{name: "no error TODOs in CI with no-ci-fail returns 0", count: 3, ci: true, noCIFail: true, want: 0},
-		{name: "no error zero TODOs in CI returns 0", count: 0, ci: true, want: 0},
+		{name: "error in CI still 1", err: errors.New("boom"), ci: true, ciFailCount: 5, want: 1},
+		{name: "no error no warning-level TODOs returns 0", want: 0},
+		{name: "no error warning-level TODOs not in CI returns 0", ciFailCount: 3, want: 0},
+		{name: "no error warning-level TODOs in CI returns 1", ciFailCount: 3, ci: true, want: 1},
+		{name: "no error warning-level TODOs in CI with no-ci-fail returns 0", ciFailCount: 3, ci: true, noCIFail: true, want: 0},
+		{name: "no error zero warning-level TODOs in CI returns 0", ciFailCount: 0, ci: true, want: 0},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := exitCode(tt.err, tt.count, tt.ci, tt.noCIFail); got != tt.want {
-				t.Fatalf("exitCode(err=%v, count=%d, ci=%v, noCIFail=%v) = %d, expected %d",
-					tt.err, tt.count, tt.ci, tt.noCIFail, got, tt.want)
+			if got := exitCode(tt.err, tt.ciFailCount, tt.ci, tt.noCIFail); got != tt.want {
+				t.Fatalf("exitCode(err=%v, ciFailCount=%d, ci=%v, noCIFail=%v) = %d, expected %d",
+					tt.err, tt.ciFailCount, tt.ci, tt.noCIFail, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestNewRunResultCountsWarningLevelTODOs(t *testing.T) {
+	todos := []types.TODO{
+		{Type: "TODO"},
+		{Type: "NOTE"},
+		{Type: "FIXME"},
+		{Type: "HACK"},
+		{Type: "XXX"},
+		{Type: "BUG"},
+	}
+
+	got := newRunResult(todos)
+	if got.totalCount != 6 {
+		t.Fatalf("newRunResult().totalCount = %d, expected 6", got.totalCount)
+	}
+	if got.ciFailCount != 4 {
+		t.Fatalf("newRunResult().ciFailCount = %d, expected 4", got.ciFailCount)
+	}
+	if code := exitCode(nil, got.ciFailCount, true, false); code != 1 {
+		t.Fatalf("exitCode() with warning-level TODOs in CI = %d, expected 1", code)
+	}
+
+	noticeOnly := newRunResult([]types.TODO{{Type: "TODO"}, {Type: "NOTE"}})
+	if noticeOnly.ciFailCount != 0 {
+		t.Fatalf("newRunResult() for notice-only TODOs ciFailCount = %d, expected 0", noticeOnly.ciFailCount)
+	}
+	if code := exitCode(nil, noticeOnly.ciFailCount, true, false); code != 0 {
+		t.Fatalf("exitCode() with notice-only TODOs in CI = %d, expected 0", code)
 	}
 }
 
@@ -545,44 +575,44 @@ index 0000000..1111111 100644
 
 	for _, tt := range tests {
 		t.Run("runMain/"+tt.name, func(t *testing.T) {
-			var gotCount int
+			var gotResult runResult
 			var gotErr error
 			_, _, _ = captureAll(t, func() {
-				gotCount, gotErr = runMain(tt.fetcher, "o/r", "1", types.GroupByNone, false)
+				gotResult, gotErr = runMain(tt.fetcher, "o/r", "1", types.GroupByNone, false)
 			})
 			if gotErr != nil {
 				t.Fatalf("runMain() unexpected error = %v", gotErr)
 			}
-			if gotCount != tt.wantCount {
-				t.Fatalf("runMain() count = %d, expected %d", gotCount, tt.wantCount)
+			if gotResult.totalCount != tt.wantCount {
+				t.Fatalf("runMain() count = %d, expected %d", gotResult.totalCount, tt.wantCount)
 			}
 		})
 
 		t.Run("runCount/"+tt.name, func(t *testing.T) {
-			var gotCount int
+			var gotResult runResult
 			var gotErr error
 			_, _, _ = captureAll(t, func() {
-				gotCount, gotErr = runCount(tt.fetcher, "o/r", "1")
+				gotResult, gotErr = runCount(tt.fetcher, "o/r", "1")
 			})
 			if gotErr != nil {
 				t.Fatalf("runCount() unexpected error = %v", gotErr)
 			}
-			if gotCount != tt.wantCount {
-				t.Fatalf("runCount() count = %d, expected %d", gotCount, tt.wantCount)
+			if gotResult.totalCount != tt.wantCount {
+				t.Fatalf("runCount() count = %d, expected %d", gotResult.totalCount, tt.wantCount)
 			}
 		})
 
 		t.Run("runNameOnly/"+tt.name, func(t *testing.T) {
-			var gotCount int
+			var gotResult runResult
 			var gotErr error
 			_, _, _ = captureAll(t, func() {
-				gotCount, gotErr = runNameOnly(tt.fetcher, "o/r", "1")
+				gotResult, gotErr = runNameOnly(tt.fetcher, "o/r", "1")
 			})
 			if gotErr != nil {
 				t.Fatalf("runNameOnly() unexpected error = %v", gotErr)
 			}
-			if gotCount != tt.wantCount {
-				t.Fatalf("runNameOnly() count = %d, expected %d", gotCount, tt.wantCount)
+			if gotResult.totalCount != tt.wantCount {
+				t.Fatalf("runNameOnly() count = %d, expected %d", gotResult.totalCount, tt.wantCount)
 			}
 		})
 	}
@@ -591,46 +621,46 @@ index 0000000..1111111 100644
 func TestRunFunctionsReturnZeroCountOnError(t *testing.T) {
 	t.Run("runMain", func(t *testing.T) {
 		fetcher := &stubFetcher{diffErr: errors.New("boom")}
-		var gotCount int
+		var gotResult runResult
 		var gotErr error
 		_, _, _ = captureAll(t, func() {
-			gotCount, gotErr = runMain(fetcher, "", "", types.GroupByNone, false)
+			gotResult, gotErr = runMain(fetcher, "", "", types.GroupByNone, false)
 		})
 		if gotErr == nil {
 			t.Fatalf("runMain() expected error, got nil")
 		}
-		if gotCount != 0 {
-			t.Fatalf("runMain() count = %d, expected 0", gotCount)
+		if gotResult.totalCount != 0 {
+			t.Fatalf("runMain() count = %d, expected 0", gotResult.totalCount)
 		}
 	})
 
 	t.Run("runCount", func(t *testing.T) {
 		fetcher := &stubFetcher{diffErr: errors.New("boom")}
-		var gotCount int
+		var gotResult runResult
 		var gotErr error
 		_, _, _ = captureAll(t, func() {
-			gotCount, gotErr = runCount(fetcher, "", "")
+			gotResult, gotErr = runCount(fetcher, "", "")
 		})
 		if gotErr == nil {
 			t.Fatalf("runCount() expected error, got nil")
 		}
-		if gotCount != 0 {
-			t.Fatalf("runCount() count = %d, expected 0", gotCount)
+		if gotResult.totalCount != 0 {
+			t.Fatalf("runCount() count = %d, expected 0", gotResult.totalCount)
 		}
 	})
 
 	t.Run("runNameOnly", func(t *testing.T) {
 		fetcher := &stubFetcher{diffErr: errors.New("boom")}
-		var gotCount int
+		var gotResult runResult
 		var gotErr error
 		_, _, _ = captureAll(t, func() {
-			gotCount, gotErr = runNameOnly(fetcher, "", "")
+			gotResult, gotErr = runNameOnly(fetcher, "", "")
 		})
 		if gotErr == nil {
 			t.Fatalf("runNameOnly() expected error, got nil")
 		}
-		if gotCount != 0 {
-			t.Fatalf("runNameOnly() count = %d, expected 0", gotCount)
+		if gotResult.totalCount != 0 {
+			t.Fatalf("runNameOnly() count = %d, expected 0", gotResult.totalCount)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

- Align CI failure behavior with GitHub Actions warning annotations
- Share TODO type warning classification between workflow annotations and exit-code logic
- Document that TODO/NOTE remain notice-only and do not fail CI

Tests:
- go test -v ./...
- go build -v ./...
- golangci-lint run
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/suree33/gh-pr-todo/pull/75" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->