### PR TITLE
feat(ci-exit): align CI failure with workflow command severity

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,11 +71,11 @@ gh pr-todo --group-by file
 - `--name-only`: Display only names of the files containing TODO comments
 - `-c, --count`: Display only the number of TODO comments
 - `-h, --help`: Display help information
-- `--no-ci-fail`: Disable non-zero exit when TODOs are found in CI (see below)
+- `--no-ci-fail`: Disable non-zero exit when warning-level TODOs (FIXME, HACK, XXX, BUG) are found in CI (see below)
 
 ### CI Mode
 
-When the `CI` environment variable is set to a truthy value (e.g. `1`, `true`, parsed via Go's `strconv.ParseBool`), `gh pr-todo` exits with status `1` if any TODO-style comments are detected in the PR diff. This makes it easy to fail a CI job when new TODOs slip into a pull request. `GITHUB_ACTIONS=true` (set automatically by the GitHub Actions runner) is treated as `CI=true` even when the `CI` variable is missing or falsy.
+When the `CI` environment variable is set to a truthy value (e.g. `1`, `true`, parsed via Go's `strconv.ParseBool`), `gh pr-todo` exits with status `1` if any **warning-level** TODO-style comments (`FIXME`, `HACK`, `XXX`, `BUG`) are detected in the PR diff. Notice-level keywords (`TODO`, `NOTE`, ...) do **not** trigger a non-zero exit, matching the severity of the GitHub Actions workflow command annotations described below. This makes it easy to fail a CI job when something that needs attention slips into a pull request, while leaving plain TODO/NOTE reminders informational. `GITHUB_ACTIONS=true` (set automatically by the GitHub Actions runner) is treated as `CI=true` even when the `CI` variable is missing or falsy.
 
 ```yaml
 # GitHub Actions example — CI=true is set automatically

--- a/internal/output/workflow.go
+++ b/internal/output/workflow.go
@@ -33,6 +33,25 @@ func workflowCommandFor(todoType string) string {
 	}
 }
 
+// IsCIFailing reports whether a TODO of the given type should cause a
+// non-zero exit in CI. It mirrors the severity used in GitHub Actions
+// workflow commands: warning-level types fail, notice-level types do not.
+func IsCIFailing(todoType string) bool {
+	return workflowCommandFor(todoType) == "warning"
+}
+
+// CountCIFailing returns the number of TODOs whose type maps to a
+// warning-level workflow command.
+func CountCIFailing(todos []types.TODO) int {
+	n := 0
+	for _, t := range todos {
+		if IsCIFailing(t.Type) {
+			n++
+		}
+	}
+	return n
+}
+
 func escapeWorkflowMessage(s string) string {
 	s = strings.ReplaceAll(s, "%", "%25")
 	s = strings.ReplaceAll(s, "\r", "%0D")

--- a/main.go
+++ b/main.go
@@ -15,26 +15,35 @@ import (
 	"github.com/spf13/pflag"
 )
 
+type cliFlags struct {
+	repo     string
+	nameOnly bool
+	count    bool
+	help     bool
+	noCIFail bool
+	groupBy  types.GroupBy
+}
+
+// registerFlags registers all CLI flags on fs and returns the bound values.
+// main() and tests share this so help/usage text never drifts between them.
+func registerFlags(fs *pflag.FlagSet) *cliFlags {
+	f := &cliFlags{groupBy: types.GroupByNone}
+	fs.StringVarP(&f.repo, "repo", "R", "", "Select another repository using the [HOST/]OWNER/REPO format")
+	fs.BoolVar(&f.nameOnly, "name-only", false, "Display only names of the files containing TODO comments")
+	fs.BoolVarP(&f.count, "count", "c", false, "Display only the number of TODO comments")
+	fs.BoolVarP(&f.help, "help", "h", false, "Display help information")
+	fs.BoolVar(&f.noCIFail, "no-ci-fail", false, "Disable non-zero exit when warning-level TODOs (FIXME, HACK, XXX, BUG) are found in CI")
+	fs.Var(&f.groupBy, "group-by", "Group TODO comments by: \"file\" or \"type\"")
+	return f
+}
+
 func main() {
-	var (
-		repo     string
-		nameOnly bool
-		isCount  bool
-		isHelp   bool
-		noCIFail bool
-		groupBy  = types.GroupByNone
-	)
-	pflag.StringVarP(&repo, "repo", "R", "", "Select another repository using the [HOST/]OWNER/REPO format")
-	pflag.BoolVar(&nameOnly, "name-only", false, "Display only names of the files containing TODO comments")
-	pflag.BoolVarP(&isCount, "count", "c", false, "Display only the number of TODO comments")
-	pflag.BoolVarP(&isHelp, "help", "h", false, "Display help information")
-	pflag.BoolVar(&noCIFail, "no-ci-fail", false, "Disable non-zero exit when warning-level TODOs (FIXME, HACK, XXX, BUG) are found in CI")
-	pflag.Var(&groupBy, "group-by", "Group TODO comments by: \"file\" or \"type\"")
+	flags := registerFlags(pflag.CommandLine)
 	pflag.Usage = printUsage
 	pflag.Parse()
 	args := pflag.Args()
 
-	if isHelp {
+	if flags.help {
 		pflag.Usage()
 		os.Exit(0)
 	}
@@ -42,7 +51,7 @@ func main() {
 	var pr string
 	switch len(args) {
 	case 0:
-		if repo != "" {
+		if flags.repo != "" {
 			fmt.Fprintf(color.Output, "%s%s\n", output.Red("✗"), " PR number, branch, or URL required when specifying repository\n")
 			pflag.Usage()
 			os.Exit(1)
@@ -63,17 +72,17 @@ func main() {
 		ciFailingCount int
 	)
 	switch {
-	case nameOnly:
-		ciFailingCount, err = runNameOnly(fetcher, repo, pr)
-	case isCount:
-		ciFailingCount, err = runCount(fetcher, repo, pr)
+	case flags.nameOnly:
+		ciFailingCount, err = runNameOnly(fetcher, flags.repo, pr)
+	case flags.count:
+		ciFailingCount, err = runCount(fetcher, flags.repo, pr)
 	default:
-		ciFailingCount, err = runMain(fetcher, repo, pr, groupBy, gha)
+		ciFailingCount, err = runMain(fetcher, flags.repo, pr, flags.groupBy, gha)
 	}
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 	}
-	os.Exit(exitCode(err, ciFailingCount, isCI(), noCIFail))
+	os.Exit(exitCode(err, ciFailingCount, isCI(), flags.noCIFail))
 }
 
 func exitCode(err error, ciFailingCount int, ci, noCIFail bool) int {

--- a/main.go
+++ b/main.go
@@ -125,7 +125,9 @@ func printUsage() {
 	})
 	fmt.Fprintln(color.Output)
 	fmt.Fprintf(color.Output, "%s\n", output.Bold("ENVIRONMENT"))
-	fmt.Fprintf(color.Output, "  %s\n", "CI               When truthy (e.g. \"1\", \"true\"), exits non-zero if any TODO is found.")
+	fmt.Fprintf(color.Output, "  %s\n", "CI               When truthy (e.g. \"1\", \"true\"), exits non-zero if any warning-level TODO")
+	fmt.Fprintf(color.Output, "  %s\n", "                 (FIXME, HACK, XXX, BUG) is found. Notice-level types (TODO, NOTE, ...) do not")
+	fmt.Fprintf(color.Output, "  %s\n", "                 trigger a failure, matching the GitHub Actions workflow command severity.")
 	fmt.Fprintf(color.Output, "  %s\n", "                 Override with --no-ci-fail.")
 	fmt.Fprintf(color.Output, "  %s\n", "GITHUB_ACTIONS   When truthy, emits GitHub Actions workflow commands so each TODO appears as an annotation.")
 	fmt.Fprintf(color.Output, "  %s\n", "                 Only emitted in the default mode; --count and --name-only stay machine-readable.")
@@ -162,7 +164,7 @@ func runMain(fetcher ghclient.PRFetcher, repo, pr string, groupBy types.GroupBy,
 	if gha {
 		output.PrintWorkflowCommands(todos)
 	}
-	return len(todos), nil
+	return output.CountCIFailing(todos), nil
 }
 
 func runCount(fetcher ghclient.PRFetcher, repo, pr string) (int, error) {
@@ -171,7 +173,7 @@ func runCount(fetcher ghclient.PRFetcher, repo, pr string) (int, error) {
 		return 0, err
 	}
 	output.PrintCount(todos)
-	return len(todos), nil
+	return output.CountCIFailing(todos), nil
 }
 
 func runNameOnly(fetcher ghclient.PRFetcher, repo, pr string) (int, error) {
@@ -180,5 +182,5 @@ func runNameOnly(fetcher ghclient.PRFetcher, repo, pr string) (int, error) {
 		return 0, err
 	}
 	output.PrintFileNames(todos)
-	return len(todos), nil
+	return output.CountCIFailing(todos), nil
 }

--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ func main() {
 	pflag.BoolVar(&nameOnly, "name-only", false, "Display only names of the files containing TODO comments")
 	pflag.BoolVarP(&isCount, "count", "c", false, "Display only the number of TODO comments")
 	pflag.BoolVarP(&isHelp, "help", "h", false, "Display help information")
-	pflag.BoolVar(&noCIFail, "no-ci-fail", false, "Disable non-zero exit when TODOs are found in CI")
+	pflag.BoolVar(&noCIFail, "no-ci-fail", false, "Disable non-zero exit when warning-level TODOs (FIXME, HACK, XXX, BUG) are found in CI")
 	pflag.Var(&groupBy, "group-by", "Group TODO comments by: \"file\" or \"type\"")
 	pflag.Usage = printUsage
 	pflag.Parse()
@@ -59,28 +59,28 @@ func main() {
 	fetcher := ghclient.NewClient()
 	gha := isGitHubActions()
 	var (
-		err   error
-		count int
+		err            error
+		ciFailingCount int
 	)
 	switch {
 	case nameOnly:
-		count, err = runNameOnly(fetcher, repo, pr)
+		ciFailingCount, err = runNameOnly(fetcher, repo, pr)
 	case isCount:
-		count, err = runCount(fetcher, repo, pr)
+		ciFailingCount, err = runCount(fetcher, repo, pr)
 	default:
-		count, err = runMain(fetcher, repo, pr, groupBy, gha)
+		ciFailingCount, err = runMain(fetcher, repo, pr, groupBy, gha)
 	}
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 	}
-	os.Exit(exitCode(err, count, isCI(), noCIFail))
+	os.Exit(exitCode(err, ciFailingCount, isCI(), noCIFail))
 }
 
-func exitCode(err error, count int, ci, noCIFail bool) int {
+func exitCode(err error, ciFailingCount int, ci, noCIFail bool) int {
 	if err != nil {
 		return 1
 	}
-	if ci && !noCIFail && count > 0 {
+	if ci && !noCIFail && ciFailingCount > 0 {
 		return 1
 	}
 	return 0

--- a/main_test.go
+++ b/main_test.go
@@ -518,6 +518,18 @@ index 0000000..1111111 100644
 		"foo.go": []byte("package foo\n// TODO: add bar\n// FIXME: fix baz\n"),
 	}
 
+	noteOnlyDiff := `diff --git a/foo.go b/foo.go
+index 0000000..1111111 100644
+--- a/foo.go
++++ b/foo.go
+@@ -1,1 +1,2 @@
+ package foo
++// NOTE: just a note
+`
+	noteOnlyFiles := map[string][]byte{
+		"foo.go": []byte("package foo\n// NOTE: just a note\n"),
+	}
+
 	tests := []struct {
 		name      string
 		fetcher   *stubFetcher
@@ -529,17 +541,22 @@ index 0000000..1111111 100644
 			wantCount: 0,
 		},
 		{
-			name: "one TODO returns 1",
+			name: "notice-only TODO does not fail CI",
 			fetcher: &stubFetcher{
 				diff:  sampleDiff,
 				files: map[string][]byte{"foo.go": []byte("package foo\n// TODO: add bar\n")},
 			},
-			wantCount: 1,
+			wantCount: 0,
 		},
 		{
-			name:      "two TODOs returns 2",
+			name:      "NOTE-only does not fail CI",
+			fetcher:   &stubFetcher{diff: noteOnlyDiff, files: noteOnlyFiles},
+			wantCount: 0,
+		},
+		{
+			name:      "FIXME among TODOs counts as ci-failing",
 			fetcher:   &stubFetcher{diff: twoTODOsDiff, files: twoTODOsFiles},
-			wantCount: 2,
+			wantCount: 1,
 		},
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -657,20 +657,7 @@ func TestPrintUsage(t *testing.T) {
 	pflag.CommandLine = pflag.NewFlagSet("gh pr-todo", pflag.ContinueOnError)
 	t.Cleanup(func() { pflag.CommandLine = originalCommandLine })
 
-	var (
-		repo     string
-		nameOnly bool
-		isCount  bool
-		isHelp   bool
-		noCIFail bool
-		groupBy  = types.GroupByNone
-	)
-	pflag.StringVarP(&repo, "repo", "R", "", "Select another repository using the [HOST/]OWNER/REPO format")
-	pflag.BoolVar(&nameOnly, "name-only", false, "Display only names of the files containing TODO comments")
-	pflag.BoolVarP(&isCount, "count", "c", false, "Display only the number of TODO comments")
-	pflag.BoolVarP(&isHelp, "help", "h", false, "Display help information")
-	pflag.BoolVar(&noCIFail, "no-ci-fail", false, "Disable non-zero exit when warning-level TODOs (FIXME, HACK, XXX, BUG) are found in CI")
-	pflag.Var(&groupBy, "group-by", "Group TODO comments by: \"file\" or \"type\"")
+	_ = registerFlags(pflag.CommandLine)
 
 	var out string
 	stdout := captureStdout(t, func() {

--- a/main_test.go
+++ b/main_test.go
@@ -478,33 +478,33 @@ func TestRunFunctionsEmitWorkflowCommands(t *testing.T) {
 
 func TestExitCode(t *testing.T) {
 	tests := []struct {
-		name     string
-		err      error
-		count    int
-		ci       bool
-		noCIFail bool
-		want     int
+		name           string
+		err            error
+		ciFailingCount int
+		ci             bool
+		noCIFail       bool
+		want           int
 	}{
 		{name: "error returns 1", err: errors.New("boom"), want: 1},
-		{name: "error in CI still 1", err: errors.New("boom"), ci: true, count: 5, want: 1},
+		{name: "error in CI still 1", err: errors.New("boom"), ci: true, ciFailingCount: 5, want: 1},
 		{name: "no error no TODOs returns 0", want: 0},
-		{name: "no error TODOs not in CI returns 0", count: 3, want: 0},
-		{name: "no error TODOs in CI returns 1", count: 3, ci: true, want: 1},
-		{name: "no error TODOs in CI with no-ci-fail returns 0", count: 3, ci: true, noCIFail: true, want: 0},
-		{name: "no error zero TODOs in CI returns 0", count: 0, ci: true, want: 0},
+		{name: "no error ci-failing TODOs not in CI returns 0", ciFailingCount: 3, want: 0},
+		{name: "no error ci-failing TODOs in CI returns 1", ciFailingCount: 3, ci: true, want: 1},
+		{name: "no error ci-failing TODOs in CI with no-ci-fail returns 0", ciFailingCount: 3, ci: true, noCIFail: true, want: 0},
+		{name: "no error zero ci-failing TODOs in CI returns 0", ciFailingCount: 0, ci: true, want: 0},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := exitCode(tt.err, tt.count, tt.ci, tt.noCIFail); got != tt.want {
-				t.Fatalf("exitCode(err=%v, count=%d, ci=%v, noCIFail=%v) = %d, expected %d",
-					tt.err, tt.count, tt.ci, tt.noCIFail, got, tt.want)
+			if got := exitCode(tt.err, tt.ciFailingCount, tt.ci, tt.noCIFail); got != tt.want {
+				t.Fatalf("exitCode(err=%v, ciFailingCount=%d, ci=%v, noCIFail=%v) = %d, expected %d",
+					tt.err, tt.ciFailingCount, tt.ci, tt.noCIFail, got, tt.want)
 			}
 		})
 	}
 }
 
-func TestRunFunctionsReturnTODOCount(t *testing.T) {
+func TestRunFunctionsReturnCIFailingCount(t *testing.T) {
 	twoTODOsDiff := `diff --git a/foo.go b/foo.go
 index 0000000..1111111 100644
 --- a/foo.go

--- a/main_test.go
+++ b/main_test.go
@@ -669,7 +669,7 @@ func TestPrintUsage(t *testing.T) {
 	pflag.BoolVar(&nameOnly, "name-only", false, "Display only names of the files containing TODO comments")
 	pflag.BoolVarP(&isCount, "count", "c", false, "Display only the number of TODO comments")
 	pflag.BoolVarP(&isHelp, "help", "h", false, "Display help information")
-	pflag.BoolVar(&noCIFail, "no-ci-fail", false, "Disable non-zero exit when TODOs are found in CI")
+	pflag.BoolVar(&noCIFail, "no-ci-fail", false, "Disable non-zero exit when warning-level TODOs (FIXME, HACK, XXX, BUG) are found in CI")
 	pflag.Var(&groupBy, "group-by", "Group TODO comments by: \"file\" or \"type\"")
 
 	var out string
@@ -697,8 +697,11 @@ func TestPrintUsage(t *testing.T) {
 		"--help",
 		"--group-by",
 		"--no-ci-fail",
+		"warning-level TODOs (FIXME, HACK, XXX, BUG)",
 		"ENVIRONMENT",
 		"CI",
+		"warning-level TODO",
+		"Notice-level types (TODO, NOTE, ...) do not",
 		"GITHUB_ACTIONS",
 	}
 	for _, want := range wantContain {


### PR DESCRIPTION
## Summary

Align the CI exit-code policy with the GitHub Actions workflow command severity that this extension already emits.

Previously, with `CI=true` (or `GITHUB_ACTIONS=true`), `gh pr-todo` exited with status `1` whenever **any** TODO-style comment was found in the diff — even plain `TODO` or `NOTE` reminders. That contradicted the workflow command annotations the same run produced (`::notice` for `TODO`/`NOTE`, `::warning` for `FIXME`/`HACK`/`XXX`/`BUG`).

This PR makes both behaviors agree:

- **Warning-level** keywords (`FIXME`, `HACK`, `XXX`, `BUG`) → `::warning` annotation **and** `exit 1` in CI.
- **Notice-level** keywords (`TODO`, `NOTE`, ...) → `::notice` annotation **and** `exit 0` in CI.

`workflowCommandFor()` is the single source of truth, reused via two new helpers in the `output` package: `IsCIFailing(string) bool` and `CountCIFailing([]types.TODO) int`.

### Changes

- `internal/output/workflow.go`: add `IsCIFailing` / `CountCIFailing`, reusing `workflowCommandFor` so severity stays consistent.
- `main.go`:
  - `runMain` / `runCount` / `runNameOnly` return `output.CountCIFailing(todos)` instead of `len(todos)`.
  - Rename `count` → `ciFailingCount` (variable + `exitCode` parameter) so the new semantics are obvious at the call site.
  - Update `--no-ci-fail` flag usage and the `ENVIRONMENT` help block to describe warning-level behavior, mention `TODO`/`NOTE` are now informational, and reference the workflow-command severity mapping.
  - Extract a `cliFlags` struct + `registerFlags(*pflag.FlagSet)` helper so `main()` and `TestPrintUsage` share one definition of every flag and its help text (no more drift between source and test).
- `main_test.go`: update `TestExitCode` and the run-functions tests to assert ci-failing semantics, add a NOTE-only case, and extend `TestPrintUsage` to assert the new warning-level / notice-level wording. Use `registerFlags` instead of redefining flags in the test.
- `README.md`: rewrite the **CI Mode** section and `--no-ci-fail` bullet to match the new behavior.

### Verification

- `go test ./...` — all green
- `golangci-lint run` — 0 issues
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/suree33/gh-pr-todo/pull/76" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->