### PR TITLE
fix(todo-type): fail only on warning-level TODOs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ gh ext install Suree33/gh-pr-todo
 ```
 
 **Prerequisites:**
+
 - [GitHub CLI](https://cli.github.com/) installed and authenticated
 
 ## Usage
@@ -71,11 +72,11 @@ gh pr-todo --group-by file
 - `--name-only`: Display only names of the files containing TODO comments
 - `-c, --count`: Display only the number of TODO comments
 - `-h, --help`: Display help information
-- `--no-ci-fail`: Disable non-zero exit when TODOs are found in CI (see below)
+- `--no-ci-fail`: Disable non-zero exit when warning-level TODOs (FIXME/HACK/XXX/BUG) are found in CI (see below)
 
 ### CI Mode
 
-When the `CI` environment variable is set to a truthy value (e.g. `1`, `true`, parsed via Go's `strconv.ParseBool`), `gh pr-todo` exits with status `1` if any TODO-style comments are detected in the PR diff. This makes it easy to fail a CI job when new TODOs slip into a pull request. `GITHUB_ACTIONS=true` (set automatically by the GitHub Actions runner) is treated as `CI=true` even when the `CI` variable is missing or falsy.
+When the `CI` environment variable is truthy (e.g. `1`, `true`, parsed via Go's `strconv.ParseBool`), `gh pr-todo` exits with status `1` if any **warning-level** TODO-style comments (`FIXME`, `HACK`, `XXX`, `BUG`) are detected in the PR diff. Notice-level keywords (`TODO`, `NOTE`) do **not** cause a non-zero exit, matching the GitHub Actions annotation severity below. `GITHUB_ACTIONS=true` (set by the GitHub Actions runner) is treated as `CI=true` even when `CI` is missing or falsy.
 
 ```yaml
 # GitHub Actions example — CI=true is set automatically
@@ -120,13 +121,13 @@ Found 3 TODO comment(s)
 
 The tool recognizes TODO-style comments in various formats:
 
-| Format | Example |
-|--------|---------|
-| **C-style** | `// TODO: Fix this bug` |
-| **C-style block** | `/* HACK: Quick fix for demo */` |
-| **Shell/Python** | `# FIXME: Optimization needed` |
-| **HTML/XML** | `<!-- NOTE: Review this section -->` |
-| **Assembly/Config** | `; XXX: Temporary workaround` |
+| Format              | Example                              |
+| ------------------- | ------------------------------------ |
+| **C-style**         | `// TODO: Fix this bug`              |
+| **C-style block**   | `/* HACK: Quick fix for demo */`     |
+| **Shell/Python**    | `# FIXME: Optimization needed`       |
+| **HTML/XML**        | `<!-- NOTE: Review this section -->` |
+| **Assembly/Config** | `; XXX: Temporary workaround`        |
 
 ## Supported Keywords
 

--- a/internal/output/workflow.go
+++ b/internal/output/workflow.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Suree33/gh-pr-todo/internal/todotype"
 	"github.com/Suree33/gh-pr-todo/pkg/types"
 	"github.com/fatih/color"
 )
@@ -25,12 +26,10 @@ func PrintWorkflowCommands(todos []types.TODO) {
 }
 
 func workflowCommandFor(todoType string) string {
-	switch strings.ToUpper(todoType) {
-	case "FIXME", "HACK", "XXX", "BUG":
+	if todotype.SeverityFor(todoType) == todotype.SeverityWarning {
 		return "warning"
-	default:
-		return "notice"
 	}
+	return "notice"
 }
 
 func escapeWorkflowMessage(s string) string {

--- a/internal/todotype/todotype.go
+++ b/internal/todotype/todotype.go
@@ -1,0 +1,48 @@
+// Package todotype provides the default classification for TODO-style
+// comment types. It is the single source of truth for severity and
+// CI-failure policy.
+package todotype
+
+import (
+	"strings"
+
+	"github.com/Suree33/gh-pr-todo/pkg/types"
+)
+
+// Severity represents the GitHub Actions annotation severity level.
+type Severity string
+
+const (
+	SeverityNotice  Severity = "notice"
+	SeverityWarning Severity = "warning"
+)
+
+// SeverityFor returns the default annotation severity for a TODO type.
+// FIXME, HACK, XXX, BUG → warning. All others (TODO, NOTE, unknown) → notice.
+func SeverityFor(todoType string) Severity {
+	switch strings.ToUpper(todoType) {
+	case "FIXME", "HACK", "XXX", "BUG":
+		return SeverityWarning
+	default:
+		return SeverityNotice
+	}
+}
+
+// IsCIFailing reports whether a TODO of the given type should cause a
+// non-zero exit in CI. It mirrors the default severity: warning-level
+// types fail, notice-level types do not.
+func IsCIFailing(todoType string) bool {
+	return SeverityFor(todoType) == SeverityWarning
+}
+
+// CountCIFailing returns the number of TODOs whose type maps to a
+// CI-failing severity.
+func CountCIFailing(todos []types.TODO) int {
+	n := 0
+	for _, t := range todos {
+		if IsCIFailing(t.Type) {
+			n++
+		}
+	}
+	return n
+}

--- a/internal/todotype/todotype_test.go
+++ b/internal/todotype/todotype_test.go
@@ -1,0 +1,119 @@
+package todotype
+
+import (
+	"testing"
+
+	"github.com/Suree33/gh-pr-todo/pkg/types"
+)
+
+func TestSeverityFor(t *testing.T) {
+	tests := []struct {
+		todoType string
+		want     Severity
+	}{
+		{"TODO", SeverityNotice},
+		{"todo", SeverityNotice},
+		{"NOTE", SeverityNotice},
+		{"note", SeverityNotice},
+		{"FIXME", SeverityWarning},
+		{"fixme", SeverityWarning},
+		{"HACK", SeverityWarning},
+		{"hack", SeverityWarning},
+		{"XXX", SeverityWarning},
+		{"xxx", SeverityWarning},
+		{"BUG", SeverityWarning},
+		{"bug", SeverityWarning},
+		{"unknown", SeverityNotice},
+		{"", SeverityNotice},
+	}
+	for _, tt := range tests {
+		t.Run(tt.todoType, func(t *testing.T) {
+			if got := SeverityFor(tt.todoType); got != tt.want {
+				t.Fatalf("SeverityFor(%q) = %q, want %q", tt.todoType, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsCIFailing(t *testing.T) {
+	tests := []struct {
+		todoType string
+		want     bool
+	}{
+		{"TODO", false},
+		{"todo", false},
+		{"NOTE", false},
+		{"FIXME", true},
+		{"HACK", true},
+		{"XXX", true},
+		{"BUG", true},
+		{"unknown", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.todoType, func(t *testing.T) {
+			if got := IsCIFailing(tt.todoType); got != tt.want {
+				t.Fatalf("IsCIFailing(%q) = %v, want %v", tt.todoType, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCountCIFailing(t *testing.T) {
+	tests := []struct {
+		name  string
+		todos []types.TODO
+		want  int
+	}{
+		{name: "nil slice", todos: nil, want: 0},
+		{name: "empty slice", todos: []types.TODO{}, want: 0},
+		{
+			name: "notice only",
+			todos: []types.TODO{
+				{Type: "TODO"},
+				{Type: "NOTE"},
+				{Type: "unknown"},
+			},
+			want: 0,
+		},
+		{
+			name: "warning only",
+			todos: []types.TODO{
+				{Type: "FIXME"},
+				{Type: "HACK"},
+				{Type: "XXX"},
+				{Type: "BUG"},
+			},
+			want: 4,
+		},
+		{
+			name: "mixed notice and warning",
+			todos: []types.TODO{
+				{Type: "TODO"},
+				{Type: "NOTE"},
+				{Type: "FIXME"},
+				{Type: "HACK"},
+				{Type: "XXX"},
+				{Type: "BUG"},
+			},
+			want: 4,
+		},
+		{
+			name: "lowercase mixed",
+			todos: []types.TODO{
+				{Type: "todo"},
+				{Type: "fixme"},
+				{Type: "note"},
+				{Type: "bug"},
+			},
+			want: 2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CountCIFailing(tt.todos); got != tt.want {
+				t.Fatalf("CountCIFailing() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 
 	ghclient "github.com/Suree33/gh-pr-todo/internal/github"
 	"github.com/Suree33/gh-pr-todo/internal/output"
+	"github.com/Suree33/gh-pr-todo/internal/todotype"
 	"github.com/Suree33/gh-pr-todo/pkg/types"
 	"github.com/briandowns/spinner"
 	"github.com/fatih/color"
@@ -28,7 +29,7 @@ func main() {
 	pflag.BoolVar(&nameOnly, "name-only", false, "Display only names of the files containing TODO comments")
 	pflag.BoolVarP(&isCount, "count", "c", false, "Display only the number of TODO comments")
 	pflag.BoolVarP(&isHelp, "help", "h", false, "Display help information")
-	pflag.BoolVar(&noCIFail, "no-ci-fail", false, "Disable non-zero exit when TODOs are found in CI")
+	pflag.BoolVar(&noCIFail, "no-ci-fail", false, "Disable non-zero exit when warning-level TODOs (FIXME/HACK/XXX/BUG) are found in CI")
 	pflag.Var(&groupBy, "group-by", "Group TODO comments by: \"file\" or \"type\"")
 	pflag.Usage = printUsage
 	pflag.Parse()
@@ -59,28 +60,42 @@ func main() {
 	fetcher := ghclient.NewClient()
 	gha := isGitHubActions()
 	var (
-		err   error
-		count int
+		err    error
+		result runResult
 	)
 	switch {
 	case nameOnly:
-		count, err = runNameOnly(fetcher, repo, pr)
+		result, err = runNameOnly(fetcher, repo, pr)
 	case isCount:
-		count, err = runCount(fetcher, repo, pr)
+		result, err = runCount(fetcher, repo, pr)
 	default:
-		count, err = runMain(fetcher, repo, pr, groupBy, gha)
+		result, err = runMain(fetcher, repo, pr, groupBy, gha)
 	}
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 	}
-	os.Exit(exitCode(err, count, isCI(), noCIFail))
+	os.Exit(exitCode(err, result.ciFailingCount, isCI(), noCIFail))
 }
 
-func exitCode(err error, count int, ci, noCIFail bool) int {
+// runResult groups the total TODO count and the CI-failing count from a run.
+type runResult struct {
+	totalCount     int
+	ciFailingCount int
+}
+
+// newRunResult computes a runResult from a TODO slice.
+func newRunResult(todos []types.TODO) runResult {
+	return runResult{
+		totalCount:     len(todos),
+		ciFailingCount: todotype.CountCIFailing(todos),
+	}
+}
+
+func exitCode(err error, ciFailingCount int, ci, noCIFail bool) int {
 	if err != nil {
 		return 1
 	}
-	if ci && !noCIFail && count > 0 {
+	if ci && !noCIFail && ciFailingCount > 0 {
 		return 1
 	}
 	return 0
@@ -125,14 +140,16 @@ func printUsage() {
 	})
 	fmt.Fprintln(color.Output)
 	fmt.Fprintf(color.Output, "%s\n", output.Bold("ENVIRONMENT"))
-	fmt.Fprintf(color.Output, "  %s\n", "CI               When truthy (e.g. \"1\", \"true\"), exits non-zero if any TODO is found.")
+	fmt.Fprintf(color.Output, "  %s\n", "CI               When truthy (e.g. \"1\", \"true\"), exits non-zero if any")
+	fmt.Fprintf(color.Output, "  %s\n", "                 warning-level TODO (FIXME/HACK/XXX/BUG) is found.")
+	fmt.Fprintf(color.Output, "  %s\n", "                 Notice-only keywords (TODO, NOTE) do not cause failures.")
 	fmt.Fprintf(color.Output, "  %s\n", "                 Override with --no-ci-fail.")
-	fmt.Fprintf(color.Output, "  %s\n", "GITHUB_ACTIONS   When truthy, emits GitHub Actions workflow commands so each TODO appears as an annotation.")
-	fmt.Fprintf(color.Output, "  %s\n", "                 Only emitted in the default mode; --count and --name-only stay machine-readable.")
-	fmt.Fprintf(color.Output, "  %s\n\n", "                 Implies CI=true, so --no-ci-fail is required to suppress the non-zero exit.")
+	fmt.Fprintf(color.Output, "  %s\n", "GITHUB_ACTIONS   When truthy, emits GitHub Actions workflow annotations.")
+	fmt.Fprintf(color.Output, "  %s\n", "                 Implies CI=true; --no-ci-fail suppresses warning-level exits.")
+	fmt.Fprintf(color.Output, "  %s\n\n", "                 Only emitted in the default mode; --count and --name-only stay machine-readable.")
 }
 
-func runMain(fetcher ghclient.PRFetcher, repo, pr string, groupBy types.GroupBy, gha bool) (int, error) {
+func runMain(fetcher ghclient.PRFetcher, repo, pr string, groupBy types.GroupBy, gha bool) (runResult, error) {
 	fetchingMsg := " Fetching PR diff..."
 	var sp *spinner.Spinner
 	if !gha {
@@ -148,13 +165,13 @@ func runMain(fetcher ghclient.PRFetcher, repo, pr string, groupBy types.GroupBy,
 
 	if err != nil {
 		fmt.Fprintf(color.Output, "%s%s\n", output.Red("✗"), fetchingMsg)
-		return 0, err
+		return runResult{}, err
 	}
 	fmt.Fprintf(color.Output, "%s%s\n", output.Green("✔"), fetchingMsg)
 
 	if len(todos) == 0 {
 		fmt.Fprintf(color.Output, "\nNo TODO comments found in the diff.\n")
-		return 0, nil
+		return runResult{}, nil
 	}
 
 	fmt.Fprintf(color.Output, output.Bold("\nFound %d TODO comment(s)\n\n"), len(todos))
@@ -162,23 +179,23 @@ func runMain(fetcher ghclient.PRFetcher, repo, pr string, groupBy types.GroupBy,
 	if gha {
 		output.PrintWorkflowCommands(todos)
 	}
-	return len(todos), nil
+	return newRunResult(todos), nil
 }
 
-func runCount(fetcher ghclient.PRFetcher, repo, pr string) (int, error) {
+func runCount(fetcher ghclient.PRFetcher, repo, pr string) (runResult, error) {
 	todos, err := ghclient.CollectTODOs(fetcher, repo, pr)
 	if err != nil {
-		return 0, err
+		return runResult{}, err
 	}
 	output.PrintCount(todos)
-	return len(todos), nil
+	return newRunResult(todos), nil
 }
 
-func runNameOnly(fetcher ghclient.PRFetcher, repo, pr string) (int, error) {
+func runNameOnly(fetcher ghclient.PRFetcher, repo, pr string) (runResult, error) {
 	todos, err := ghclient.CollectTODOs(fetcher, repo, pr)
 	if err != nil {
-		return 0, err
+		return runResult{}, err
 	}
 	output.PrintFileNames(todos)
-	return len(todos), nil
+	return newRunResult(todos), nil
 }

--- a/main_test.go
+++ b/main_test.go
@@ -108,6 +108,16 @@ index 0000000..1111111 100644
 +// TODO: add bar
 `
 
+// noteOnlyDiff is a diff with a NOTE comment (no warning-level tokens).
+const noteOnlyDiff = `diff --git a/note.go b/note.go
+index 0000000..1111111 100644
+--- a/note.go
++++ b/note.go
+@@ -1,1 +1,2 @@
+ package note
++// NOTE: test note
+`
+
 func TestRunMain(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -478,33 +488,34 @@ func TestRunFunctionsEmitWorkflowCommands(t *testing.T) {
 
 func TestExitCode(t *testing.T) {
 	tests := []struct {
-		name     string
-		err      error
-		count    int
-		ci       bool
-		noCIFail bool
-		want     int
+		name           string
+		err            error
+		ciFailingCount int
+		ci             bool
+		noCIFail       bool
+		want           int
 	}{
 		{name: "error returns 1", err: errors.New("boom"), want: 1},
-		{name: "error in CI still 1", err: errors.New("boom"), ci: true, count: 5, want: 1},
+		{name: "error in CI still 1", err: errors.New("boom"), ci: true, ciFailingCount: 5, want: 1},
 		{name: "no error no TODOs returns 0", want: 0},
-		{name: "no error TODOs not in CI returns 0", count: 3, want: 0},
-		{name: "no error TODOs in CI returns 1", count: 3, ci: true, want: 1},
-		{name: "no error TODOs in CI with no-ci-fail returns 0", count: 3, ci: true, noCIFail: true, want: 0},
-		{name: "no error zero TODOs in CI returns 0", count: 0, ci: true, want: 0},
+		{name: "no error ci-failing TODOs not in CI returns 0", ciFailingCount: 3, want: 0},
+		{name: "no error ci-failing TODOs in CI returns 1", ciFailingCount: 3, ci: true, want: 1},
+		{name: "no error notice-only TODOs in CI returns 0", ciFailingCount: 0, ci: true, want: 0},
+		{name: "no error ci-failing TODOs in CI with no-ci-fail returns 0", ciFailingCount: 3, ci: true, noCIFail: true, want: 0},
+		{name: "no error zero TODOs in CI returns 0", ciFailingCount: 0, ci: true, want: 0},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := exitCode(tt.err, tt.count, tt.ci, tt.noCIFail); got != tt.want {
-				t.Fatalf("exitCode(err=%v, count=%d, ci=%v, noCIFail=%v) = %d, expected %d",
-					tt.err, tt.count, tt.ci, tt.noCIFail, got, tt.want)
+			if got := exitCode(tt.err, tt.ciFailingCount, tt.ci, tt.noCIFail); got != tt.want {
+				t.Fatalf("exitCode(err=%v, ciFailingCount=%d, ci=%v, noCIFail=%v) = %d, expected %d",
+					tt.err, tt.ciFailingCount, tt.ci, tt.noCIFail, got, tt.want)
 			}
 		})
 	}
 }
 
-func TestRunFunctionsReturnTODOCount(t *testing.T) {
+func TestRunFunctionsReturnCIFailingCount(t *testing.T) {
 	twoTODOsDiff := `diff --git a/foo.go b/foo.go
 index 0000000..1111111 100644
 --- a/foo.go
@@ -519,119 +530,145 @@ index 0000000..1111111 100644
 	}
 
 	tests := []struct {
-		name      string
-		fetcher   *stubFetcher
-		wantCount int
+		name          string
+		fetcher       *stubFetcher
+		wantTotal     int
+		wantCIFailing int
 	}{
 		{
-			name:      "no TODOs returns 0",
-			fetcher:   &stubFetcher{diff: "", files: map[string][]byte{}},
-			wantCount: 0,
+			name:          "no TODOs returns 0",
+			fetcher:       &stubFetcher{diff: "", files: map[string][]byte{}},
+			wantTotal:     0,
+			wantCIFailing: 0,
 		},
 		{
-			name: "one TODO returns 1",
+			name: "one notice TODO returns 0",
 			fetcher: &stubFetcher{
 				diff:  sampleDiff,
 				files: map[string][]byte{"foo.go": []byte("package foo\n// TODO: add bar\n")},
 			},
-			wantCount: 1,
+			wantTotal:     1,
+			wantCIFailing: 0,
 		},
 		{
-			name:      "two TODOs returns 2",
-			fetcher:   &stubFetcher{diff: twoTODOsDiff, files: twoTODOsFiles},
-			wantCount: 2,
+			name: "notice only (NOTE) returns 0",
+			fetcher: &stubFetcher{
+				diff:  noteOnlyDiff,
+				files: map[string][]byte{"note.go": []byte("package note\n// NOTE: test note\n")},
+			},
+			wantTotal:     1,
+			wantCIFailing: 0,
+		},
+		{
+			name:          "notice and warning TODOs returns 1",
+			fetcher:       &stubFetcher{diff: twoTODOsDiff, files: twoTODOsFiles},
+			wantTotal:     2,
+			wantCIFailing: 1,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run("runMain/"+tt.name, func(t *testing.T) {
-			var gotCount int
+			var result runResult
 			var gotErr error
 			_, _, _ = captureAll(t, func() {
-				gotCount, gotErr = runMain(tt.fetcher, "o/r", "1", types.GroupByNone, false)
+				result, gotErr = runMain(tt.fetcher, "o/r", "1", types.GroupByNone, false)
 			})
 			if gotErr != nil {
 				t.Fatalf("runMain() unexpected error = %v", gotErr)
 			}
-			if gotCount != tt.wantCount {
-				t.Fatalf("runMain() count = %d, expected %d", gotCount, tt.wantCount)
+			if result.totalCount != tt.wantTotal {
+				t.Fatalf("runMain() totalCount = %d, expected %d (ciFailingCount=%d)", result.totalCount, tt.wantTotal, result.ciFailingCount)
+			}
+			if result.ciFailingCount != tt.wantCIFailing {
+				t.Fatalf("runMain() ciFailingCount = %d, expected %d", result.ciFailingCount, tt.wantCIFailing)
 			}
 		})
 
 		t.Run("runCount/"+tt.name, func(t *testing.T) {
-			var gotCount int
+			var result runResult
 			var gotErr error
 			_, _, _ = captureAll(t, func() {
-				gotCount, gotErr = runCount(tt.fetcher, "o/r", "1")
+				result, gotErr = runCount(tt.fetcher, "o/r", "1")
 			})
 			if gotErr != nil {
 				t.Fatalf("runCount() unexpected error = %v", gotErr)
 			}
-			if gotCount != tt.wantCount {
-				t.Fatalf("runCount() count = %d, expected %d", gotCount, tt.wantCount)
+			if result.totalCount != tt.wantTotal {
+				t.Fatalf("runCount() totalCount = %d, expected %d (ciFailingCount=%d)", result.totalCount, tt.wantTotal, result.ciFailingCount)
+			}
+			if result.ciFailingCount != tt.wantCIFailing {
+				t.Fatalf("runCount() ciFailingCount = %d, expected %d", result.ciFailingCount, tt.wantCIFailing)
 			}
 		})
 
 		t.Run("runNameOnly/"+tt.name, func(t *testing.T) {
-			var gotCount int
+			var result runResult
 			var gotErr error
 			_, _, _ = captureAll(t, func() {
-				gotCount, gotErr = runNameOnly(tt.fetcher, "o/r", "1")
+				result, gotErr = runNameOnly(tt.fetcher, "o/r", "1")
 			})
 			if gotErr != nil {
 				t.Fatalf("runNameOnly() unexpected error = %v", gotErr)
 			}
-			if gotCount != tt.wantCount {
-				t.Fatalf("runNameOnly() count = %d, expected %d", gotCount, tt.wantCount)
+			if result.totalCount != tt.wantTotal {
+				t.Fatalf("runNameOnly() totalCount = %d, expected %d (ciFailingCount=%d)", result.totalCount, tt.wantTotal, result.ciFailingCount)
+			}
+			if result.ciFailingCount != tt.wantCIFailing {
+				t.Fatalf("runNameOnly() ciFailingCount = %d, expected %d", result.ciFailingCount, tt.wantCIFailing)
 			}
 		})
 	}
 }
 
-func TestRunFunctionsReturnZeroCountOnError(t *testing.T) {
+func TestRunFunctionsReturnZeroOnError(t *testing.T) {
+	checkZero := func(t *testing.T, label string, result runResult) {
+		t.Helper()
+		if result.totalCount != 0 {
+			t.Fatalf("%s totalCount = %d, expected 0", label, result.totalCount)
+		}
+		if result.ciFailingCount != 0 {
+			t.Fatalf("%s ciFailingCount = %d, expected 0", label, result.ciFailingCount)
+		}
+	}
+
 	t.Run("runMain", func(t *testing.T) {
 		fetcher := &stubFetcher{diffErr: errors.New("boom")}
-		var gotCount int
+		var result runResult
 		var gotErr error
 		_, _, _ = captureAll(t, func() {
-			gotCount, gotErr = runMain(fetcher, "", "", types.GroupByNone, false)
+			result, gotErr = runMain(fetcher, "", "", types.GroupByNone, false)
 		})
 		if gotErr == nil {
 			t.Fatalf("runMain() expected error, got nil")
 		}
-		if gotCount != 0 {
-			t.Fatalf("runMain() count = %d, expected 0", gotCount)
-		}
+		checkZero(t, "runMain()", result)
 	})
 
 	t.Run("runCount", func(t *testing.T) {
 		fetcher := &stubFetcher{diffErr: errors.New("boom")}
-		var gotCount int
+		var result runResult
 		var gotErr error
 		_, _, _ = captureAll(t, func() {
-			gotCount, gotErr = runCount(fetcher, "", "")
+			result, gotErr = runCount(fetcher, "", "")
 		})
 		if gotErr == nil {
 			t.Fatalf("runCount() expected error, got nil")
 		}
-		if gotCount != 0 {
-			t.Fatalf("runCount() count = %d, expected 0", gotCount)
-		}
+		checkZero(t, "runCount()", result)
 	})
 
 	t.Run("runNameOnly", func(t *testing.T) {
 		fetcher := &stubFetcher{diffErr: errors.New("boom")}
-		var gotCount int
+		var result runResult
 		var gotErr error
 		_, _, _ = captureAll(t, func() {
-			gotCount, gotErr = runNameOnly(fetcher, "", "")
+			result, gotErr = runNameOnly(fetcher, "", "")
 		})
 		if gotErr == nil {
 			t.Fatalf("runNameOnly() expected error, got nil")
 		}
-		if gotCount != 0 {
-			t.Fatalf("runNameOnly() count = %d, expected 0", gotCount)
-		}
+		checkZero(t, "runNameOnly()", result)
 	})
 }
 
@@ -652,7 +689,7 @@ func TestPrintUsage(t *testing.T) {
 	pflag.BoolVar(&nameOnly, "name-only", false, "Display only names of the files containing TODO comments")
 	pflag.BoolVarP(&isCount, "count", "c", false, "Display only the number of TODO comments")
 	pflag.BoolVarP(&isHelp, "help", "h", false, "Display help information")
-	pflag.BoolVar(&noCIFail, "no-ci-fail", false, "Disable non-zero exit when TODOs are found in CI")
+	pflag.BoolVar(&noCIFail, "no-ci-fail", false, "Disable non-zero exit when warning-level TODOs (FIXME/HACK/XXX/BUG) are found in CI")
 	pflag.Var(&groupBy, "group-by", "Group TODO comments by: \"file\" or \"type\"")
 
 	var out string
@@ -683,6 +720,9 @@ func TestPrintUsage(t *testing.T) {
 		"ENVIRONMENT",
 		"CI",
 		"GITHUB_ACTIONS",
+		"warning-level TODO (FIXME/HACK/XXX/BUG)",
+		"Notice-only keywords (TODO, NOTE)",
+		"(FIXME/HACK/XXX/BUG) are found in CI",
 	}
 	for _, want := range wantContain {
 		if !strings.Contains(out, want) {


### PR DESCRIPTION
## Summary

- Align CI exit behavior with GitHub Actions annotation severity: TODO/NOTE stay notice-only while FIXME/HACK/XXX/BUG fail CI
- Centralize default TODO type classification in internal/todotype for future configurable classification work
- Return total and CI-failing counts separately so --count output remains total TODO count
- Update tests and docs for NOTE-only, unknown type, and CI-failing behavior

Validation:
- go test ./...
- go build ./...
- golangci-lint run
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/suree33/gh-pr-todo/pull/77" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

BEGIN_COMMIT_OVERRIDE
fix(todo-type): fail only on warning-level TODOs in CI
END_COMMIT_OVERRIDE