### PR TITLE
refactor(todo-type): introduce policy-based severity model

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,18 +72,18 @@ gh pr-todo --group-by file
 - `--name-only`: Display only names of the files containing TODO comments
 - `-c, --count`: Display only the number of TODO comments
 - `-h, --help`: Display help information
-- `--no-ci-fail`: Disable non-zero exit when warning-level TODOs (FIXME/HACK/XXX/BUG) are found in CI (see below)
+- `--no-ci-fail`: Disable non-zero exit when error-level TODOs are found in CI (see below)
 
 ### CI Mode
 
-When the `CI` environment variable is truthy (e.g. `1`, `true`, parsed via Go's `strconv.ParseBool`), `gh pr-todo` exits with status `1` if any **warning-level** TODO-style comments (`FIXME`, `HACK`, `XXX`, `BUG`) are detected in the PR diff. Notice-level keywords (`TODO`, `NOTE`) do **not** cause a non-zero exit, matching the GitHub Actions annotation severity below. `GITHUB_ACTIONS=true` (set by the GitHub Actions runner) is treated as `CI=true` even when `CI` is missing or falsy.
+When the `CI` environment variable is truthy (e.g. `1`, `true`, parsed via Go's `strconv.ParseBool`), `gh pr-todo` exits with status `1` if any **error-level** TODO-style comments are detected in the PR diff. By default, no built-in keyword type is mapped to error-level, so `gh pr-todo` does **not** fail CI based on default keywords alone. Users can configure custom type-to-severity mappings in future releases to introduce error-level types. `GITHUB_ACTIONS=true` (set by the GitHub Actions runner) is treated as `CI=true` even when `CI` is missing or falsy.
 
 ```yaml
 # GitHub Actions example — CI=true is set automatically
 - run: gh pr-todo ${{ github.event.pull_request.number }}
 ```
 
-Pass `--no-ci-fail` to keep the informational behavior even in CI:
+Pass `--no-ci-fail` to suppress non-zero exit even when error-level TODOs exist:
 
 ```bash
 gh pr-todo --count --no-ci-fail
@@ -95,6 +95,8 @@ When `GITHUB_ACTIONS=true` (set automatically by the GitHub Actions runner), `gh
 
 - `TODO`, `NOTE` → `::notice` annotations
 - `FIXME`, `HACK`, `XXX`, `BUG` → `::warning` annotations
+
+Annotations reflect the severity of each keyword and are independent of CI exit behavior: warning annotations are displayed but do **not** cause a non-zero exit by default. Only error-level TODOs (none by default) cause CI failure.
 
 Each annotation is anchored to the file and line of the TODO, with the keyword used as the annotation title. Regular human-readable output is still printed, and the spinner is suppressed to keep Actions logs clean.
 

--- a/internal/output/workflow.go
+++ b/internal/output/workflow.go
@@ -26,11 +26,7 @@ func PrintWorkflowCommands(todos []types.TODO) {
 }
 
 func workflowCommandFor(todoType string) string {
-	return workflowCommand(todotype.SeverityFor(todoType))
-}
-
-func workflowCommand(severity todotype.Severity) string {
-	switch severity {
+	switch todotype.SeverityFor(todoType) {
 	case todotype.SeverityWarning:
 		return "warning"
 	case todotype.SeverityError:

--- a/internal/output/workflow.go
+++ b/internal/output/workflow.go
@@ -26,10 +26,18 @@ func PrintWorkflowCommands(todos []types.TODO) {
 }
 
 func workflowCommandFor(todoType string) string {
-	if todotype.SeverityFor(todoType) == todotype.SeverityWarning {
+	return workflowCommand(todotype.SeverityFor(todoType))
+}
+
+func workflowCommand(severity todotype.Severity) string {
+	switch severity {
+	case todotype.SeverityWarning:
 		return "warning"
+	case todotype.SeverityError:
+		return "error"
+	default:
+		return "notice"
 	}
-	return "notice"
 }
 
 func escapeWorkflowMessage(s string) string {

--- a/internal/output/workflow_test.go
+++ b/internal/output/workflow_test.go
@@ -3,6 +3,7 @@ package output
 import (
 	"testing"
 
+	"github.com/Suree33/gh-pr-todo/internal/todotype"
 	"github.com/Suree33/gh-pr-todo/pkg/types"
 )
 
@@ -118,6 +119,26 @@ func TestWorkflowCommandFor(t *testing.T) {
 		t.Run(tt.todoType, func(t *testing.T) {
 			if got := workflowCommandFor(tt.todoType); got != tt.want {
 				t.Fatalf("workflowCommandFor(%q) = %q, want %q", tt.todoType, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWorkflowCommand(t *testing.T) {
+	tests := []struct {
+		name     string
+		severity todotype.Severity
+		want     string
+	}{
+		{name: "notice", severity: todotype.SeverityNotice, want: "notice"},
+		{name: "warning", severity: todotype.SeverityWarning, want: "warning"},
+		{name: "error", severity: todotype.SeverityError, want: "error"},
+		{name: "unknown falls back to notice", severity: todotype.Severity("unexpected"), want: "notice"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := workflowCommand(tt.severity); got != tt.want {
+				t.Fatalf("workflowCommand(%q) = %q, want %q", tt.severity, got, tt.want)
 			}
 		})
 	}

--- a/internal/output/workflow_test.go
+++ b/internal/output/workflow_test.go
@@ -3,7 +3,6 @@ package output
 import (
 	"testing"
 
-	"github.com/Suree33/gh-pr-todo/internal/todotype"
 	"github.com/Suree33/gh-pr-todo/pkg/types"
 )
 
@@ -119,26 +118,6 @@ func TestWorkflowCommandFor(t *testing.T) {
 		t.Run(tt.todoType, func(t *testing.T) {
 			if got := workflowCommandFor(tt.todoType); got != tt.want {
 				t.Fatalf("workflowCommandFor(%q) = %q, want %q", tt.todoType, got, tt.want)
-			}
-		})
-	}
-}
-
-func TestWorkflowCommand(t *testing.T) {
-	tests := []struct {
-		name     string
-		severity todotype.Severity
-		want     string
-	}{
-		{name: "notice", severity: todotype.SeverityNotice, want: "notice"},
-		{name: "warning", severity: todotype.SeverityWarning, want: "warning"},
-		{name: "error", severity: todotype.SeverityError, want: "error"},
-		{name: "unknown falls back to notice", severity: todotype.Severity("unexpected"), want: "notice"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := workflowCommand(tt.severity); got != tt.want {
-				t.Fatalf("workflowCommand(%q) = %q, want %q", tt.severity, got, tt.want)
 			}
 		})
 	}

--- a/internal/todotype/todotype.go
+++ b/internal/todotype/todotype.go
@@ -90,23 +90,28 @@ func (p Policy) CountCIFailing(todos []types.TODO) int {
 	return n
 }
 
+// defaultPolicy is a cached immutable Policy reused by the package-level
+// wrappers to avoid rebuilding maps on every call. DefaultPolicy() still
+// returns a fresh copy for callers who need a configurable instance.
+var defaultPolicy = DefaultPolicy()
+
 // SeverityFor returns the default annotation severity for a TODO type.
 // FIXME, HACK, XXX, BUG → warning. All others (TODO, NOTE, unknown) → notice.
 func SeverityFor(todoType string) Severity {
-	return DefaultPolicy().SeverityFor(todoType)
+	return defaultPolicy.SeverityFor(todoType)
 }
 
 // IsCIFailing reports whether a TODO of the given type should cause a
 // non-zero exit in CI. It mirrors the default severity: warning-level
 // and error-level types fail, notice-level types do not.
 func IsCIFailing(todoType string) bool {
-	return DefaultPolicy().IsCIFailing(todoType)
+	return defaultPolicy.IsCIFailing(todoType)
 }
 
 // CountCIFailing returns the number of TODOs whose type maps to a
 // CI-failing severity.
 func CountCIFailing(todos []types.TODO) int {
-	return DefaultPolicy().CountCIFailing(todos)
+	return defaultPolicy.CountCIFailing(todos)
 }
 
 func normalizeTodoType(todoType string) string {

--- a/internal/todotype/todotype.go
+++ b/internal/todotype/todotype.go
@@ -34,8 +34,7 @@ func DefaultPolicy() Policy {
 			"BUG":   SeverityWarning,
 		},
 		ciFailingSeverities: map[Severity]bool{
-			SeverityWarning: true,
-			SeverityError:   true,
+			SeverityError: true,
 		},
 	}
 }
@@ -73,7 +72,8 @@ func (p Policy) SeverityFor(todoType string) Severity {
 }
 
 // IsCIFailing reports whether a TODO of the given type should cause a
-// non-zero exit in CI.
+// non-zero exit in CI. By default, only error-level types fail;
+// warning-level and notice-level types do not.
 func (p Policy) IsCIFailing(todoType string) bool {
 	return p.ciFailingSeverities[p.SeverityFor(todoType)]
 }
@@ -102,8 +102,8 @@ func SeverityFor(todoType string) Severity {
 }
 
 // IsCIFailing reports whether a TODO of the given type should cause a
-// non-zero exit in CI. It mirrors the default severity: warning-level
-// and error-level types fail, notice-level types do not.
+// non-zero exit in CI. By default, only error-level types fail;
+// warning-level and notice-level types do not.
 func IsCIFailing(todoType string) bool {
 	return defaultPolicy.IsCIFailing(todoType)
 }

--- a/internal/todotype/todotype.go
+++ b/internal/todotype/todotype.go
@@ -90,7 +90,7 @@ func (p Policy) CountCIFailing(todos []types.TODO) int {
 	return n
 }
 
-// defaultPolicy is a cached immutable Policy reused by the package-level
+// defaultPolicy is a cached shared Policy used by the package-level
 // wrappers to avoid rebuilding maps on every call. DefaultPolicy() still
 // returns a fresh copy for callers who need a configurable instance.
 var defaultPolicy = DefaultPolicy()

--- a/internal/todotype/todotype.go
+++ b/internal/todotype/todotype.go
@@ -15,34 +15,100 @@ type Severity string
 const (
 	SeverityNotice  Severity = "notice"
 	SeverityWarning Severity = "warning"
+	SeverityError   Severity = "error"
 )
+
+// Policy classifies TODO types into severities and CI-failing levels.
+type Policy struct {
+	severityByType      map[string]Severity
+	ciFailingSeverities map[Severity]bool
+}
+
+// DefaultPolicy returns the default TODO type policy.
+func DefaultPolicy() Policy {
+	return Policy{
+		severityByType: map[string]Severity{
+			"FIXME": SeverityWarning,
+			"HACK":  SeverityWarning,
+			"XXX":   SeverityWarning,
+			"BUG":   SeverityWarning,
+		},
+		ciFailingSeverities: map[Severity]bool{
+			SeverityWarning: true,
+			SeverityError:   true,
+		},
+	}
+}
+
+// WithSeverity returns a copy of the policy with a severity override for one type.
+func (p Policy) WithSeverity(todoType string, severity Severity) Policy {
+	return p.WithSeverities(map[string]Severity{todoType: severity})
+}
+
+// WithSeverities returns a copy of the policy with severity overrides applied.
+func (p Policy) WithSeverities(overrides map[string]Severity) Policy {
+	clone := Policy{
+		severityByType:      make(map[string]Severity, len(p.severityByType)+len(overrides)),
+		ciFailingSeverities: make(map[Severity]bool, len(p.ciFailingSeverities)),
+	}
+	for todoType, severity := range p.severityByType {
+		clone.severityByType[todoType] = severity
+	}
+	for severity, failing := range p.ciFailingSeverities {
+		clone.ciFailingSeverities[severity] = failing
+	}
+	for todoType, severity := range overrides {
+		clone.severityByType[normalizeTodoType(todoType)] = severity
+	}
+	return clone
+}
+
+// SeverityFor returns the annotation severity for a TODO type.
+func (p Policy) SeverityFor(todoType string) Severity {
+	severity, ok := p.severityByType[normalizeTodoType(todoType)]
+	if !ok {
+		return SeverityNotice
+	}
+	return severity
+}
+
+// IsCIFailing reports whether a TODO of the given type should cause a
+// non-zero exit in CI.
+func (p Policy) IsCIFailing(todoType string) bool {
+	return p.ciFailingSeverities[p.SeverityFor(todoType)]
+}
+
+// CountCIFailing returns the number of TODOs whose type maps to a
+// CI-failing severity.
+func (p Policy) CountCIFailing(todos []types.TODO) int {
+	n := 0
+	for _, t := range todos {
+		if p.IsCIFailing(t.Type) {
+			n++
+		}
+	}
+	return n
+}
 
 // SeverityFor returns the default annotation severity for a TODO type.
 // FIXME, HACK, XXX, BUG → warning. All others (TODO, NOTE, unknown) → notice.
 func SeverityFor(todoType string) Severity {
-	switch strings.ToUpper(todoType) {
-	case "FIXME", "HACK", "XXX", "BUG":
-		return SeverityWarning
-	default:
-		return SeverityNotice
-	}
+	return DefaultPolicy().SeverityFor(todoType)
 }
 
 // IsCIFailing reports whether a TODO of the given type should cause a
 // non-zero exit in CI. It mirrors the default severity: warning-level
-// types fail, notice-level types do not.
+// and error-level types fail, notice-level types do not.
 func IsCIFailing(todoType string) bool {
-	return SeverityFor(todoType) == SeverityWarning
+	return DefaultPolicy().IsCIFailing(todoType)
 }
 
 // CountCIFailing returns the number of TODOs whose type maps to a
 // CI-failing severity.
 func CountCIFailing(todos []types.TODO) int {
-	n := 0
-	for _, t := range todos {
-		if IsCIFailing(t.Type) {
-			n++
-		}
-	}
-	return n
+	return DefaultPolicy().CountCIFailing(todos)
+}
+
+func normalizeTodoType(todoType string) string {
+	return strings.ToUpper(todoType)
 }

--- a/internal/todotype/todotype_test.go
+++ b/internal/todotype/todotype_test.go
@@ -44,10 +44,10 @@ func TestIsCIFailing(t *testing.T) {
 		{"TODO", false},
 		{"todo", false},
 		{"NOTE", false},
-		{"FIXME", true},
-		{"HACK", true},
-		{"XXX", true},
-		{"BUG", true},
+		{"FIXME", false},
+		{"HACK", false},
+		{"XXX", false},
+		{"BUG", false},
 		{"unknown", false},
 		{"", false},
 	}
@@ -85,7 +85,7 @@ func TestCountCIFailing(t *testing.T) {
 				{Type: "XXX"},
 				{Type: "BUG"},
 			},
-			want: 4,
+			want: 0,
 		},
 		{
 			name: "mixed notice and warning",
@@ -97,7 +97,7 @@ func TestCountCIFailing(t *testing.T) {
 				{Type: "XXX"},
 				{Type: "BUG"},
 			},
-			want: 4,
+			want: 0,
 		},
 		{
 			name: "lowercase mixed",
@@ -107,7 +107,7 @@ func TestCountCIFailing(t *testing.T) {
 				{Type: "note"},
 				{Type: "bug"},
 			},
-			want: 2,
+			want: 0,
 		},
 	}
 	for _, tt := range tests {
@@ -142,17 +142,17 @@ func TestDefaultPolicy(t *testing.T) {
 		}
 	})
 
-	t.Run("DefaultPolicy().IsCIFailing matches warning/error severities", func(t *testing.T) {
+	t.Run("DefaultPolicy().IsCIFailing matches error-only severity", func(t *testing.T) {
 		tests := []struct {
 			todoType string
 			want     bool
 		}{
 			{"TODO", false},
 			{"NOTE", false},
-			{"FIXME", true},
-			{"HACK", true},
-			{"XXX", true},
-			{"BUG", true},
+			{"FIXME", false},
+			{"HACK", false},
+			{"XXX", false},
+			{"BUG", false},
 			{"unknown", false},
 		}
 		for _, tt := range tests {
@@ -169,8 +169,8 @@ func TestDefaultPolicy(t *testing.T) {
 			{Type: "NOTE"},
 			{Type: "BUG"},
 		}
-		if got := p.CountCIFailing(todos); got != 2 {
-			t.Fatalf("CountCIFailing() = %d, want 2", got)
+		if got := p.CountCIFailing(todos); got != 0 {
+			t.Fatalf("CountCIFailing() = %d, want 0", got)
 		}
 	})
 }
@@ -185,9 +185,9 @@ func TestPolicyWithSeverity(t *testing.T) {
 		if got := p.SeverityFor("FIXME"); got != SeverityWarning {
 			t.Fatalf("SeverityFor(FIXME) = %q, want %q", got, SeverityWarning)
 		}
-		// CI fail: TODO is now warning, so it should fail
-		if !p.IsCIFailing("TODO") {
-			t.Fatal("IsCIFailing(TODO) should be true after override to warning")
+		// CI fail: warning does NOT fail CI by default (only error does)
+		if p.IsCIFailing("TODO") {
+			t.Fatal("IsCIFailing(TODO) should be false after override to warning")
 		}
 	})
 
@@ -259,14 +259,14 @@ func TestPolicyWithSeverity(t *testing.T) {
 }
 
 func TestPolicyCountCIFailingWithOverrides(t *testing.T) {
-	t.Run("custom type with warning severity fails CI", func(t *testing.T) {
+	t.Run("custom type with warning severity does not fail CI", func(t *testing.T) {
 		p := DefaultPolicy().WithSeverity("OPTIMIZE", SeverityWarning)
 		todos := []types.TODO{
 			{Type: "OPTIMIZE"},
 			{Type: "TODO"},
 		}
-		if got := p.CountCIFailing(todos); got != 1 {
-			t.Fatalf("CountCIFailing() = %d, want 1", got)
+		if got := p.CountCIFailing(todos); got != 0 {
+			t.Fatalf("CountCIFailing() = %d, want 0", got)
 		}
 	})
 

--- a/internal/todotype/todotype_test.go
+++ b/internal/todotype/todotype_test.go
@@ -24,6 +24,7 @@ func TestSeverityFor(t *testing.T) {
 		{"BUG", SeverityWarning},
 		{"bug", SeverityWarning},
 		{"unknown", SeverityNotice},
+		{" FIXME ", SeverityNotice},
 		{"", SeverityNotice},
 	}
 	for _, tt := range tests {
@@ -115,5 +116,193 @@ func TestCountCIFailing(t *testing.T) {
 				t.Fatalf("CountCIFailing() = %d, want %d", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestDefaultPolicy(t *testing.T) {
+	p := DefaultPolicy()
+
+	t.Run("DefaultPolicy().SeverityFor returns defaults", func(t *testing.T) {
+		tests := []struct {
+			todoType string
+			want     Severity
+		}{
+			{"TODO", SeverityNotice},
+			{"FIXME", SeverityWarning},
+			{"HACK", SeverityWarning},
+			{"XXX", SeverityWarning},
+			{"BUG", SeverityWarning},
+			{"NOTE", SeverityNotice},
+			{"unknown", SeverityNotice},
+		}
+		for _, tt := range tests {
+			if got := p.SeverityFor(tt.todoType); got != tt.want {
+				t.Fatalf("SeverityFor(%q) = %q, want %q", tt.todoType, got, tt.want)
+			}
+		}
+	})
+
+	t.Run("DefaultPolicy().IsCIFailing matches warning/error severities", func(t *testing.T) {
+		tests := []struct {
+			todoType string
+			want     bool
+		}{
+			{"TODO", false},
+			{"NOTE", false},
+			{"FIXME", true},
+			{"HACK", true},
+			{"XXX", true},
+			{"BUG", true},
+			{"unknown", false},
+		}
+		for _, tt := range tests {
+			if got := p.IsCIFailing(tt.todoType); got != tt.want {
+				t.Fatalf("IsCIFailing(%q) = %v, want %v", tt.todoType, got, tt.want)
+			}
+		}
+	})
+
+	t.Run("DefaultPolicy().CountCIFailing computes correctly", func(t *testing.T) {
+		todos := []types.TODO{
+			{Type: "TODO"},
+			{Type: "FIXME"},
+			{Type: "NOTE"},
+			{Type: "BUG"},
+		}
+		if got := p.CountCIFailing(todos); got != 2 {
+			t.Fatalf("CountCIFailing() = %d, want 2", got)
+		}
+	})
+}
+
+func TestPolicyWithSeverity(t *testing.T) {
+	t.Run("override single type", func(t *testing.T) {
+		p := DefaultPolicy().WithSeverity("TODO", SeverityWarning)
+		if got := p.SeverityFor("TODO"); got != SeverityWarning {
+			t.Fatalf("SeverityFor(TODO) = %q, want %q", got, SeverityWarning)
+		}
+		// unchanged types preserved
+		if got := p.SeverityFor("FIXME"); got != SeverityWarning {
+			t.Fatalf("SeverityFor(FIXME) = %q, want %q", got, SeverityWarning)
+		}
+		// CI fail: TODO is now warning, so it should fail
+		if !p.IsCIFailing("TODO") {
+			t.Fatal("IsCIFailing(TODO) should be true after override to warning")
+		}
+	})
+
+	t.Run("override to error severity", func(t *testing.T) {
+		p := DefaultPolicy().WithSeverity("TODO", SeverityError)
+		if got := p.SeverityFor("TODO"); got != SeverityError {
+			t.Fatalf("SeverityFor(TODO) = %q, want %q", got, SeverityError)
+		}
+		// CI fail: error severity should also fail
+		if !p.IsCIFailing("TODO") {
+			t.Fatal("IsCIFailing(TODO) should be true after override to error")
+		}
+	})
+
+	t.Run("add custom TODO type", func(t *testing.T) {
+		p := DefaultPolicy().WithSeverity("REVIEW", SeverityWarning)
+		if got := p.SeverityFor("REVIEW"); got != SeverityWarning {
+			t.Fatalf("SeverityFor(REVIEW) = %q, want %q", got, SeverityWarning)
+		}
+		if got := p.SeverityFor("review"); got != SeverityWarning {
+			t.Fatalf("SeverityFor(review) = %q, want %q", got, SeverityWarning)
+		}
+		// Default types still work
+		if got := p.SeverityFor("TODO"); got != SeverityNotice {
+			t.Fatalf("SeverityFor(TODO) = %q, want %q", got, SeverityNotice)
+		}
+	})
+
+	t.Run("WithSeverities bulk override", func(t *testing.T) {
+		p := DefaultPolicy().WithSeverities(map[string]Severity{
+			"TODO":   SeverityWarning,
+			"REVIEW": SeverityError,
+		})
+		if got := p.SeverityFor("TODO"); got != SeverityWarning {
+			t.Fatalf("SeverityFor(TODO) = %q, want %q", got, SeverityWarning)
+		}
+		if got := p.SeverityFor("REVIEW"); got != SeverityError {
+			t.Fatalf("SeverityFor(REVIEW) = %q, want %q", got, SeverityError)
+		}
+		if got := p.SeverityFor("FIXME"); got != SeverityWarning {
+			t.Fatalf("SeverityFor(FIXME) = %q, want %q", got, SeverityWarning)
+		}
+	})
+
+	t.Run("immutability: original unchanged after override", func(t *testing.T) {
+		orig := DefaultPolicy()
+		_ = orig.WithSeverity("TODO", SeverityWarning)
+		if got := orig.SeverityFor("TODO"); got != SeverityNotice {
+			t.Fatalf("original policy SeverityFor(TODO) = %q, want %q (unchanged)", got, SeverityNotice)
+		}
+	})
+
+	t.Run("override with lowercase type", func(t *testing.T) {
+		p := DefaultPolicy().WithSeverity("todo", SeverityWarning)
+		if got := p.SeverityFor("TODO"); got != SeverityWarning {
+			t.Fatalf("SeverityFor(TODO) = %q, want %q after setting lowercased key", got, SeverityWarning)
+		}
+	})
+
+	t.Run("normalization does not trim spaces", func(t *testing.T) {
+		p := DefaultPolicy().WithSeverity(" review ", SeverityWarning)
+		if got := p.SeverityFor("REVIEW"); got != SeverityNotice {
+			t.Fatalf("SeverityFor(REVIEW) = %q, want %q without trimming", got, SeverityNotice)
+		}
+		if got := p.SeverityFor(" review "); got != SeverityWarning {
+			t.Fatalf("SeverityFor(\" review \") = %q, want %q", got, SeverityWarning)
+		}
+	})
+}
+
+func TestPolicyCountCIFailingWithOverrides(t *testing.T) {
+	t.Run("custom type with warning severity fails CI", func(t *testing.T) {
+		p := DefaultPolicy().WithSeverity("OPTIMIZE", SeverityWarning)
+		todos := []types.TODO{
+			{Type: "OPTIMIZE"},
+			{Type: "TODO"},
+		}
+		if got := p.CountCIFailing(todos); got != 1 {
+			t.Fatalf("CountCIFailing() = %d, want 1", got)
+		}
+	})
+
+	t.Run("custom type with notice severity does not fail CI", func(t *testing.T) {
+		p := DefaultPolicy().WithSeverity("OPTIMIZE", SeverityNotice)
+		todos := []types.TODO{
+			{Type: "OPTIMIZE"},
+		}
+		if got := p.CountCIFailing(todos); got != 0 {
+			t.Fatalf("CountCIFailing() = %d, want 0", got)
+		}
+	})
+
+	t.Run("custom type with error severity fails CI", func(t *testing.T) {
+		p := DefaultPolicy().WithSeverity("OPTIMIZE", SeverityError)
+		todos := []types.TODO{
+			{Type: "OPTIMIZE"},
+		}
+		if got := p.CountCIFailing(todos); got != 1 {
+			t.Fatalf("CountCIFailing() = %d, want 1", got)
+		}
+	})
+}
+
+func TestPackageLevelFunctionsUseDefaultPolicy(t *testing.T) {
+	// Ensures package-level functions delegate to DefaultPolicy
+	if got := SeverityFor("FIXME"); got != DefaultPolicy().SeverityFor("FIXME") {
+		t.Fatal("SeverityFor does not match DefaultPolicy")
+	}
+	if got := IsCIFailing("FIXME"); got != DefaultPolicy().IsCIFailing("FIXME") {
+		t.Fatal("IsCIFailing does not match DefaultPolicy")
+	}
+}
+
+func TestSeverityErrorConstant(t *testing.T) {
+	if SeverityError != "error" {
+		t.Fatalf("SeverityError = %q, want 'error'", SeverityError)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ func main() {
 	pflag.BoolVar(&nameOnly, "name-only", false, "Display only names of the files containing TODO comments")
 	pflag.BoolVarP(&isCount, "count", "c", false, "Display only the number of TODO comments")
 	pflag.BoolVarP(&isHelp, "help", "h", false, "Display help information")
-	pflag.BoolVar(&noCIFail, "no-ci-fail", false, "Disable non-zero exit when warning-level TODOs (FIXME/HACK/XXX/BUG) are found in CI")
+	pflag.BoolVar(&noCIFail, "no-ci-fail", false, "Disable non-zero exit when error-level TODOs are found in CI")
 	pflag.Var(&groupBy, "group-by", "Group TODO comments by: \"file\" or \"type\"")
 	pflag.Usage = printUsage
 	pflag.Parse()
@@ -141,11 +141,11 @@ func printUsage() {
 	fmt.Fprintln(color.Output)
 	fmt.Fprintf(color.Output, "%s\n", output.Bold("ENVIRONMENT"))
 	fmt.Fprintf(color.Output, "  %s\n", "CI               When truthy (e.g. \"1\", \"true\"), exits non-zero if any")
-	fmt.Fprintf(color.Output, "  %s\n", "                 warning-level TODO (FIXME/HACK/XXX/BUG) is found.")
-	fmt.Fprintf(color.Output, "  %s\n", "                 Notice-only keywords (TODO, NOTE) do not cause failures.")
-	fmt.Fprintf(color.Output, "  %s\n", "                 Override with --no-ci-fail.")
+	fmt.Fprintf(color.Output, "  %s\n", "                 error-level TODO is found. By default, no built-in")
+	fmt.Fprintf(color.Output, "  %s\n", "                 keyword maps to error-level, so CI does not fail.")
+	fmt.Fprintf(color.Output, "  %s\n", "                 Use --no-ci-fail to disable even if error-level types exist.")
 	fmt.Fprintf(color.Output, "  %s\n", "GITHUB_ACTIONS   When truthy, emits GitHub Actions workflow annotations.")
-	fmt.Fprintf(color.Output, "  %s\n", "                 Implies CI=true; --no-ci-fail suppresses warning-level exits.")
+	fmt.Fprintf(color.Output, "  %s\n", "                 Implies CI=true; --no-ci-fail suppresses error-level exits.")
 	fmt.Fprintf(color.Output, "  %s\n\n", "                 Only emitted in the default mode; --count and --name-only stay machine-readable.")
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -460,7 +460,7 @@ func TestRunFunctionsEmitWorkflowCommands(t *testing.T) {
 		out, _, _ := captureAll(t, func() {
 			_, _ = runMain(fetcher, "o/r", "1", types.GroupByNone, false)
 		})
-		if strings.Contains(out, "::notice ") || strings.Contains(out, "::warning ") {
+		if strings.Contains(out, "::notice ") || strings.Contains(out, "::warning ") || strings.Contains(out, "::error ") {
 			t.Fatalf("runMain(gha=false) unexpectedly emitted workflow command: %q", out)
 		}
 	})
@@ -470,7 +470,7 @@ func TestRunFunctionsEmitWorkflowCommands(t *testing.T) {
 		out, _, _ := captureAll(t, func() {
 			_, _ = runCount(fetcher, "o/r", "1")
 		})
-		if strings.Contains(out, "::notice") || strings.Contains(out, "::warning") {
+		if strings.Contains(out, "::notice") || strings.Contains(out, "::warning") || strings.Contains(out, "::error") {
 			t.Fatalf("runCount must not emit workflow commands; got %q", out)
 		}
 	})
@@ -480,7 +480,7 @@ func TestRunFunctionsEmitWorkflowCommands(t *testing.T) {
 		out, _, _ := captureAll(t, func() {
 			_, _ = runNameOnly(fetcher, "o/r", "1")
 		})
-		if strings.Contains(out, "::notice") || strings.Contains(out, "::warning") {
+		if strings.Contains(out, "::notice") || strings.Contains(out, "::warning") || strings.Contains(out, "::error") {
 			t.Fatalf("runNameOnly must not emit workflow commands; got %q", out)
 		}
 	})

--- a/main_test.go
+++ b/main_test.go
@@ -560,10 +560,10 @@ index 0000000..1111111 100644
 			wantCIFailing: 0,
 		},
 		{
-			name:          "notice and warning TODOs returns 1",
+			name:          "notice and warning TODOs returns 0 CI failures (warning is not error)",
 			fetcher:       &stubFetcher{diff: twoTODOsDiff, files: twoTODOsFiles},
 			wantTotal:     2,
-			wantCIFailing: 1,
+			wantCIFailing: 0,
 		},
 	}
 
@@ -689,7 +689,7 @@ func TestPrintUsage(t *testing.T) {
 	pflag.BoolVar(&nameOnly, "name-only", false, "Display only names of the files containing TODO comments")
 	pflag.BoolVarP(&isCount, "count", "c", false, "Display only the number of TODO comments")
 	pflag.BoolVarP(&isHelp, "help", "h", false, "Display help information")
-	pflag.BoolVar(&noCIFail, "no-ci-fail", false, "Disable non-zero exit when warning-level TODOs (FIXME/HACK/XXX/BUG) are found in CI")
+	pflag.BoolVar(&noCIFail, "no-ci-fail", false, "Disable non-zero exit when error-level TODOs are found in CI")
 	pflag.Var(&groupBy, "group-by", "Group TODO comments by: \"file\" or \"type\"")
 
 	var out string
@@ -720,9 +720,10 @@ func TestPrintUsage(t *testing.T) {
 		"ENVIRONMENT",
 		"CI",
 		"GITHUB_ACTIONS",
-		"warning-level TODO (FIXME/HACK/XXX/BUG)",
-		"Notice-only keywords (TODO, NOTE)",
-		"(FIXME/HACK/XXX/BUG) are found in CI",
+		"error-level TODO is found.",
+		"By default, no built-in",
+		"keyword maps to error-level",
+		"--no-ci-fail",
 	}
 	for _, want := range wantContain {
 		if !strings.Contains(out, want) {


### PR DESCRIPTION
## Summary

- refactor TODO type severity handling behind a policy model while preserving the current default behavior
- add `error` as an internal severity, cache the shared default policy, and map it correctly for GitHub Actions workflow commands
- expand `internal/todotype` tests to cover default compatibility, override behavior, custom TODO types, and CI-failing severity handling
