### PR TITLE
ci: run gh pr-todo on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,3 +80,23 @@ jobs:
 
       - name: Actionlint
         run: docker run --rm -v "$(pwd):$(pwd)" -w "$(pwd)" rhysd/actionlint:latest -color
+
+  pr-todo:
+    name: PR TODO Check
+    if: github.event_name == 'pull_request'
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+
+    steps:
+      - name: Install gh-pr-todo extension
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh extension install Suree33/gh-pr-todo
+
+      - name: Run gh-pr-todo
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr-todo -R "${GITHUB_REPOSITORY}" "${{ github.event.pull_request.number }}"


### PR DESCRIPTION
## Summary

- add a dedicated `PR TODO Check` job to the CI workflow
- install and run the latest released `gh pr-todo` on pull request events
- keep the check read-only and preserve the default CI failure behavior
