### PR TITLE
feat: add configurable severity overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ gh pr-todo -c
 
 # Group TODO comments by file (or type)
 gh pr-todo --group-by file
+
+# Override severities for one or more TODO types
+# Format: --severity LEVEL=TYPE[,TYPE...]
+gh pr-todo --severity warning=TODO,HACK --severity error=FIXME
 ```
 
 ### Command Options
@@ -71,12 +75,13 @@ gh pr-todo --group-by file
 - `--group-by`: Group TODO comments by `file` or `type`
 - `--name-only`: Display only names of the files containing TODO comments
 - `-c, --count`: Display only the number of TODO comments
+- `--severity LEVEL=TYPE[,TYPE...]`: Override severity for one or more TODO types; repeatable, whitespace-tolerant, and last assignment wins for duplicate types
 - `-h, --help`: Display help information
 - `--no-ci-fail`: Disable non-zero exit when error-level TODOs are found in CI (see below)
 
 ### CI Mode
 
-When the `CI` environment variable is truthy (e.g. `1`, `true`, parsed via Go's `strconv.ParseBool`), `gh pr-todo` exits with status `1` if any **error-level** TODO-style comments are detected in the PR diff. By default, no built-in keyword type is mapped to error-level, so `gh pr-todo` does **not** fail CI based on default keywords alone. Users can configure custom type-to-severity mappings in future releases to introduce error-level types. `GITHUB_ACTIONS=true` (set by the GitHub Actions runner) is treated as `CI=true` even when `CI` is missing or falsy.
+When the `CI` environment variable is truthy (e.g. `1`, `true`, parsed via Go's `strconv.ParseBool`), `gh pr-todo` exits with status `1` if any **error-level** TODO-style comments are detected in the PR diff. By default, no built-in keyword type is mapped to error-level, so `gh pr-todo` does **not** fail CI based on default keywords alone. Use `--severity` to promote any built-in or custom type to `error` when you want CI failures, for example `--severity error=FIXME`. `GITHUB_ACTIONS=true` (set by the GitHub Actions runner) is treated as `CI=true` even when `CI` is missing or falsy.
 
 ```yaml
 # GitHub Actions example — CI=true is set automatically
@@ -86,17 +91,24 @@ When the `CI` environment variable is truthy (e.g. `1`, `true`, parsed via Go's 
 Pass `--no-ci-fail` to suppress non-zero exit even when error-level TODOs exist:
 
 ```bash
-gh pr-todo --count --no-ci-fail
+gh pr-todo --count --severity error=FIXME --no-ci-fail
 ```
 
 ### GitHub Actions Annotations
 
 When `GITHUB_ACTIONS=true` (set automatically by the GitHub Actions runner), `gh pr-todo` additionally emits [workflow commands](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands) so each TODO appears as an annotation on the workflow run and pull request:
 
+Default annotation severities:
+
 - `TODO`, `NOTE` → `::notice` annotations
 - `FIXME`, `HACK`, `XXX`, `BUG` → `::warning` annotations
 
-Annotations reflect the severity of each keyword and are independent of CI exit behavior: warning annotations are displayed but do **not** cause a non-zero exit by default. Only error-level TODOs (none by default) cause CI failure.
+You can override them with `--severity`, for example:
+
+- `--severity warning=TODO,NOTE`
+- `--severity error=FIXME`
+
+Annotations reflect the resolved severity of each keyword and are independent of CI exit behavior: warning annotations are displayed but do **not** cause a non-zero exit by default. Only error-level TODOs cause CI failure.
 
 Each annotation is anchored to the file and line of the TODO, with the keyword used as the annotation title. Regular human-readable output is still printed, and the spinner is suppressed to keep Actions logs clean.
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ gh pr-todo --severity warning=TODO,HACK --severity error=FIXME
 
 ### CI Mode
 
-When the `CI` environment variable is truthy (e.g. `1`, `true`, parsed via Go's `strconv.ParseBool`), `gh pr-todo` exits with status `1` if any **error-level** TODO-style comments are detected in the PR diff. By default, no built-in keyword type is mapped to error-level, so `gh pr-todo` does **not** fail CI based on default keywords alone. Use `--severity` to promote any built-in or custom type to `error` when you want CI failures, for example `--severity error=FIXME`. `GITHUB_ACTIONS=true` (set by the GitHub Actions runner) is treated as `CI=true` even when `CI` is missing or falsy.
+When the `CI` environment variable is truthy (e.g. `1`, `true`, parsed via Go's `strconv.ParseBool`), `gh pr-todo` exits with status `1` if any **error-level** TODO-style comments are detected in the PR diff. By default, no built-in keyword type is mapped to error-level, so `gh pr-todo` does **not** fail CI based on default keywords alone. Use `--severity` to promote recognized TODO keywords to `error` when you want CI failures, for example `--severity error=FIXME`. `GITHUB_ACTIONS=true` (set by the GitHub Actions runner) is treated as `CI=true` even when `CI` is missing or falsy.
 
 ```yaml
 # GitHub Actions example — CI=true is set automatically

--- a/internal/output/workflow.go
+++ b/internal/output/workflow.go
@@ -13,10 +13,10 @@ import (
 // for each TODO so that they show up in the PR/check-run UI.
 //
 // See https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands
-func PrintWorkflowCommands(todos []types.TODO) {
+func PrintWorkflowCommands(todos []types.TODO, policy todotype.Policy) {
 	for _, todo := range todos {
 		fmt.Fprintf(color.Output, "::%s file=%s,line=%d,title=%s::%s\n",
-			workflowCommandFor(todo.Type),
+			workflowCommandFor(todo.Type, policy),
 			escapeWorkflowProperty(todo.Filename),
 			todo.Line,
 			escapeWorkflowProperty(todo.Type),
@@ -25,8 +25,8 @@ func PrintWorkflowCommands(todos []types.TODO) {
 	}
 }
 
-func workflowCommandFor(todoType string) string {
-	switch todotype.SeverityFor(todoType) {
+func workflowCommandFor(todoType string, policy todotype.Policy) string {
+	switch policy.SeverityFor(todoType) {
 	case todotype.SeverityWarning:
 		return "warning"
 	case todotype.SeverityError:

--- a/internal/output/workflow_test.go
+++ b/internal/output/workflow_test.go
@@ -3,6 +3,7 @@ package output
 import (
 	"testing"
 
+	"github.com/Suree33/gh-pr-todo/internal/todotype"
 	"github.com/Suree33/gh-pr-todo/pkg/types"
 )
 
@@ -24,10 +25,29 @@ func TestPrintWorkflowCommands(t *testing.T) {
 		"::notice file=f.go,line=1,title=NOTE::// NOTE: f\n"
 
 	got := captureOutput(t, func() {
-		PrintWorkflowCommands(todos)
+		PrintWorkflowCommands(todos, todotype.DefaultPolicy())
 	})
 	if got != want {
 		t.Fatalf("PrintWorkflowCommands() output mismatch\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
+func TestPrintWorkflowCommandsWithPolicy(t *testing.T) {
+	policy := todotype.DefaultPolicy().WithSeverity("TODO", todotype.SeverityWarning)
+
+	todos := []types.TODO{
+		{Filename: "a.go", Line: 5, Comment: "// TODO: a", Type: "TODO"},
+		{Filename: "b.go", Line: 20, Comment: "// FIXME: b", Type: "FIXME"},
+	}
+
+	want := "::warning file=a.go,line=5,title=TODO::// TODO: a\n" +
+		"::warning file=b.go,line=20,title=FIXME::// FIXME: b\n"
+
+	got := captureOutput(t, func() {
+		PrintWorkflowCommands(todos, policy)
+	})
+	if got != want {
+		t.Fatalf("PrintWorkflowCommands() with policy output mismatch\ngot:  %q\nwant: %q", got, want)
 	}
 }
 
@@ -45,7 +65,7 @@ func TestPrintWorkflowCommandsAppliesEscaping(t *testing.T) {
 		"// TODO: 100%25 rate%0D%0Arest of comment\n"
 
 	got := captureOutput(t, func() {
-		PrintWorkflowCommands(todos)
+		PrintWorkflowCommands(todos, todotype.DefaultPolicy())
 	})
 	if got != want {
 		t.Fatalf("PrintWorkflowCommands escaping mismatch\ngot:  %q\nwant: %q", got, want)
@@ -54,7 +74,7 @@ func TestPrintWorkflowCommandsAppliesEscaping(t *testing.T) {
 
 func TestPrintWorkflowCommandsEmpty(t *testing.T) {
 	got := captureOutput(t, func() {
-		PrintWorkflowCommands(nil)
+		PrintWorkflowCommands(nil, todotype.DefaultPolicy())
 	})
 	if got != "" {
 		t.Fatalf("PrintWorkflowCommands(nil) = %q, want empty", got)
@@ -114,9 +134,10 @@ func TestWorkflowCommandFor(t *testing.T) {
 		{"BUG", "warning"},
 		{"unknown", "notice"},
 	}
+	policy := todotype.DefaultPolicy()
 	for _, tt := range tests {
 		t.Run(tt.todoType, func(t *testing.T) {
-			if got := workflowCommandFor(tt.todoType); got != tt.want {
+			if got := workflowCommandFor(tt.todoType, policy); got != tt.want {
 				t.Fatalf("workflowCommandFor(%q) = %q, want %q", tt.todoType, got, tt.want)
 			}
 		})

--- a/main.go
+++ b/main.go
@@ -226,10 +226,11 @@ func printUsage() {
 	fmt.Fprintf(color.Output, "  %s\n", "                 Use --no-ci-fail to disable even if error-level types exist.")
 	fmt.Fprintf(color.Output, "  %s\n", "GITHUB_ACTIONS   When truthy, emits GitHub Actions workflow annotations.")
 	fmt.Fprintf(color.Output, "  %s\n", "                 Implies CI=true; --no-ci-fail suppresses error-level exits.")
-	fmt.Fprintf(color.Output, "  %s\n", "                 Only emitted in the default mode; --count and --name-only stay machine-readable.")
-	fmt.Fprintf(color.Output, "  %s\n", "SEVERITY FLAG    Use --severity LEVEL=TYPE[,TYPE...] to override severities.")
-	fmt.Fprintf(color.Output, "  %s\n", "                 Affects workflow annotation levels and CI exits for error-level types.")
-	fmt.Fprintf(color.Output, "  %s\n\n", "                 Example: --severity warning=TODO,HACK --severity error=FIXME")
+	fmt.Fprintf(color.Output, "  %s\n\n", "                 Only emitted in the default mode; --count and --name-only stay machine-readable.")
+	fmt.Fprintf(color.Output, "%s\n", output.Bold("SEVERITY OVERRIDES"))
+	fmt.Fprintf(color.Output, "  %s\n", "Use --severity LEVEL=TYPE[,TYPE...] to override severities.")
+	fmt.Fprintf(color.Output, "  %s\n", "Affects workflow annotation levels and CI exits for error-level types.")
+	fmt.Fprintf(color.Output, "  %s\n\n", "Example: --severity warning=TODO,HACK --severity error=FIXME")
 }
 
 func runMain(fetcher ghclient.PRFetcher, repo, pr string, groupBy types.GroupBy, gha bool, policy todotype.Policy) (runResult, error) {

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -17,6 +18,11 @@ import (
 )
 
 func main() {
+	// Use ContinueOnError so we can print a clear error and exit code 1
+	// instead of pflag's default ExitOnError (exit code 2).
+	pflag.CommandLine = pflag.NewFlagSet("gh pr-todo", pflag.ContinueOnError)
+	pflag.CommandLine.SetOutput(io.Discard)
+
 	var (
 		repo     string
 		nameOnly bool
@@ -24,6 +30,7 @@ func main() {
 		isHelp   bool
 		noCIFail bool
 		groupBy  = types.GroupByNone
+		sevFlag  = newSeverityFlag()
 	)
 	pflag.StringVarP(&repo, "repo", "R", "", "Select another repository using the [HOST/]OWNER/REPO format")
 	pflag.BoolVar(&nameOnly, "name-only", false, "Display only names of the files containing TODO comments")
@@ -31,8 +38,12 @@ func main() {
 	pflag.BoolVarP(&isHelp, "help", "h", false, "Display help information")
 	pflag.BoolVar(&noCIFail, "no-ci-fail", false, "Disable non-zero exit when error-level TODOs are found in CI")
 	pflag.Var(&groupBy, "group-by", "Group TODO comments by: \"file\" or \"type\"")
+	pflag.Var(sevFlag, "severity", "Override severity for one or more TODO types. Format: LEVEL=TYPE[,TYPE...] (e.g. --severity warning=TODO,HACK)")
 	pflag.Usage = printUsage
-	pflag.Parse()
+	if err := pflag.CommandLine.Parse(os.Args[1:]); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
 	args := pflag.Args()
 
 	if isHelp {
@@ -57,6 +68,11 @@ func main() {
 		os.Exit(1)
 	}
 
+	policy := todotype.DefaultPolicy()
+	if len(sevFlag.assignments) > 0 {
+		policy = policy.WithSeverities(sevFlag.assignments)
+	}
+
 	fetcher := ghclient.NewClient()
 	gha := isGitHubActions()
 	var (
@@ -65,11 +81,11 @@ func main() {
 	)
 	switch {
 	case nameOnly:
-		result, err = runNameOnly(fetcher, repo, pr)
+		result, err = runNameOnly(fetcher, repo, pr, policy)
 	case isCount:
-		result, err = runCount(fetcher, repo, pr)
+		result, err = runCount(fetcher, repo, pr, policy)
 	default:
-		result, err = runMain(fetcher, repo, pr, groupBy, gha)
+		result, err = runMain(fetcher, repo, pr, groupBy, gha, policy)
 	}
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -83,11 +99,75 @@ type runResult struct {
 	ciFailingCount int
 }
 
-// newRunResult computes a runResult from a TODO slice.
-func newRunResult(todos []types.TODO) runResult {
+// severityFlag accumulates --severity LEVEL=TYPE[,TYPE...] flag values.
+// Each flag adds one or more type→severity assignments; later assignments
+// for the same type (case-insensitive) replace earlier ones (last-wins).
+type severityFlag struct {
+	assignments map[string]todotype.Severity
+}
+
+func newSeverityFlag() *severityFlag {
+	return &severityFlag{assignments: make(map[string]todotype.Severity)}
+}
+
+func (s *severityFlag) String() string {
+	return fmt.Sprintf("%v", s.assignments)
+}
+
+func (s *severityFlag) Set(val string) error {
+	eq := strings.IndexByte(val, '=')
+	if eq < 0 {
+		return fmt.Errorf("invalid --severity %q: expected LEVEL=TYPE[,TYPE...] (e.g. warning=TODO,HACK)", val)
+	}
+
+	levelStr := strings.TrimSpace(val[:eq])
+	typesStr := strings.TrimSpace(val[eq+1:])
+
+	if levelStr == "" {
+		return fmt.Errorf("invalid --severity %q: severity level is empty", val)
+	}
+	if typesStr == "" {
+		return fmt.Errorf("invalid --severity %q: type list is empty", val)
+	}
+
+	var severity todotype.Severity
+	switch strings.ToLower(levelStr) {
+	case "notice":
+		severity = todotype.SeverityNotice
+	case "warning":
+		severity = todotype.SeverityWarning
+	case "error":
+		severity = todotype.SeverityError
+	default:
+		return fmt.Errorf("invalid severity level %q in --severity %q: allowed values are notice, warning, error", levelStr, val)
+	}
+
+	pending := make(map[string]todotype.Severity)
+	for _, typ := range strings.Split(typesStr, ",") {
+		t := strings.TrimSpace(typ)
+		if t == "" {
+			return fmt.Errorf("invalid --severity %q: type name is empty", val)
+		}
+		if strings.ContainsRune(t, '=') {
+			return fmt.Errorf("invalid --severity %q: type name %q must not contain '='", val, t)
+		}
+		// Normalize type to uppercase for last-wins semantics across flags.
+		pending[strings.ToUpper(t)] = severity
+	}
+	for todoType, severity := range pending {
+		s.assignments[todoType] = severity
+	}
+
+	return nil
+}
+
+func (s *severityFlag) Type() string { return "severity" }
+
+// newRunResult computes a runResult from a TODO slice using the given policy.
+func newRunResult(todos []types.TODO, policy todotype.Policy) runResult {
 	return runResult{
 		totalCount:     len(todos),
-		ciFailingCount: todotype.CountCIFailing(todos),
+		ciFailingCount: policy.CountCIFailing(todos),
 	}
 }
 
@@ -146,10 +226,13 @@ func printUsage() {
 	fmt.Fprintf(color.Output, "  %s\n", "                 Use --no-ci-fail to disable even if error-level types exist.")
 	fmt.Fprintf(color.Output, "  %s\n", "GITHUB_ACTIONS   When truthy, emits GitHub Actions workflow annotations.")
 	fmt.Fprintf(color.Output, "  %s\n", "                 Implies CI=true; --no-ci-fail suppresses error-level exits.")
-	fmt.Fprintf(color.Output, "  %s\n\n", "                 Only emitted in the default mode; --count and --name-only stay machine-readable.")
+	fmt.Fprintf(color.Output, "  %s\n", "                 Only emitted in the default mode; --count and --name-only stay machine-readable.")
+	fmt.Fprintf(color.Output, "  %s\n", "SEVERITY FLAG    Use --severity LEVEL=TYPE[,TYPE...] to override severities.")
+	fmt.Fprintf(color.Output, "  %s\n", "                 Affects workflow annotation levels and CI exits for error-level types.")
+	fmt.Fprintf(color.Output, "  %s\n\n", "                 Example: --severity warning=TODO,HACK --severity error=FIXME")
 }
 
-func runMain(fetcher ghclient.PRFetcher, repo, pr string, groupBy types.GroupBy, gha bool) (runResult, error) {
+func runMain(fetcher ghclient.PRFetcher, repo, pr string, groupBy types.GroupBy, gha bool, policy todotype.Policy) (runResult, error) {
 	fetchingMsg := " Fetching PR diff..."
 	var sp *spinner.Spinner
 	if !gha {
@@ -177,25 +260,25 @@ func runMain(fetcher ghclient.PRFetcher, repo, pr string, groupBy types.GroupBy,
 	fmt.Fprintf(color.Output, output.Bold("\nFound %d TODO comment(s)\n\n"), len(todos))
 	output.PrintTODOs(todos, groupBy)
 	if gha {
-		output.PrintWorkflowCommands(todos)
+		output.PrintWorkflowCommands(todos, policy)
 	}
-	return newRunResult(todos), nil
+	return newRunResult(todos, policy), nil
 }
 
-func runCount(fetcher ghclient.PRFetcher, repo, pr string) (runResult, error) {
+func runCount(fetcher ghclient.PRFetcher, repo, pr string, policy todotype.Policy) (runResult, error) {
 	todos, err := ghclient.CollectTODOs(fetcher, repo, pr)
 	if err != nil {
 		return runResult{}, err
 	}
 	output.PrintCount(todos)
-	return newRunResult(todos), nil
+	return newRunResult(todos, policy), nil
 }
 
-func runNameOnly(fetcher ghclient.PRFetcher, repo, pr string) (runResult, error) {
+func runNameOnly(fetcher ghclient.PRFetcher, repo, pr string, policy todotype.Policy) (runResult, error) {
 	todos, err := ghclient.CollectTODOs(fetcher, repo, pr)
 	if err != nil {
 		return runResult{}, err
 	}
 	output.PrintFileNames(todos)
-	return newRunResult(todos), nil
+	return newRunResult(todos, policy), nil
 }

--- a/main_test.go
+++ b/main_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Suree33/gh-pr-todo/internal/todotype"
 	"github.com/Suree33/gh-pr-todo/pkg/types"
 	"github.com/fatih/color"
 	"github.com/spf13/pflag"
@@ -203,7 +204,7 @@ func TestRunMain(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var gotErr error
 			out, stdout, gotStderr := captureAll(t, func() {
-				_, gotErr = runMain(tt.fetcher, "o/r", "1", tt.groupBy, false)
+				_, gotErr = runMain(tt.fetcher, "o/r", "1", tt.groupBy, false, todotype.DefaultPolicy())
 			})
 
 			if tt.wantErr != "" {
@@ -249,7 +250,7 @@ func TestRunCount(t *testing.T) {
 		fetcher := &stubFetcher{diffErr: errors.New("boom")}
 		var err error
 		out, stdout, stderr := captureAll(t, func() {
-			_, err = runCount(fetcher, "", "")
+			_, err = runCount(fetcher, "", "", todotype.DefaultPolicy())
 		})
 		if err == nil || err.Error() != "boom" {
 			t.Fatalf("runCount() error = %v, expected boom", err)
@@ -267,7 +268,7 @@ func TestRunCount(t *testing.T) {
 		}
 		var err error
 		out, stdout, stderr := captureAll(t, func() {
-			_, err = runCount(fetcher, "o/r", "1")
+			_, err = runCount(fetcher, "o/r", "1", todotype.DefaultPolicy())
 		})
 		if err != nil {
 			t.Fatalf("runCount() unexpected error = %v", err)
@@ -287,7 +288,7 @@ func TestRunNameOnly(t *testing.T) {
 		fetcher := &stubFetcher{diffErr: errors.New("boom")}
 		var err error
 		out, stdout, stderr := captureAll(t, func() {
-			_, err = runNameOnly(fetcher, "", "")
+			_, err = runNameOnly(fetcher, "", "", todotype.DefaultPolicy())
 		})
 		if err == nil || err.Error() != "boom" {
 			t.Fatalf("runNameOnly() error = %v, expected boom", err)
@@ -305,7 +306,7 @@ func TestRunNameOnly(t *testing.T) {
 		}
 		var err error
 		out, stdout, stderr := captureAll(t, func() {
-			_, err = runNameOnly(fetcher, "o/r", "1")
+			_, err = runNameOnly(fetcher, "o/r", "1", todotype.DefaultPolicy())
 		})
 		if err != nil {
 			t.Fatalf("runNameOnly() unexpected error = %v", err)
@@ -323,7 +324,7 @@ func TestRunNameOnly(t *testing.T) {
 		fetcher := &stubFetcher{diff: "", files: map[string][]byte{}}
 		var err error
 		out, stdout, stderr := captureAll(t, func() {
-			_, err = runNameOnly(fetcher, "", "")
+			_, err = runNameOnly(fetcher, "", "", todotype.DefaultPolicy())
 		})
 		if err != nil {
 			t.Fatalf("runNameOnly() unexpected error = %v", err)
@@ -449,7 +450,7 @@ func TestRunFunctionsEmitWorkflowCommands(t *testing.T) {
 
 	t.Run("runMain emits when gha=true", func(t *testing.T) {
 		out, _, _ := captureAll(t, func() {
-			_, _ = runMain(fetcher, "o/r", "1", types.GroupByNone, true)
+			_, _ = runMain(fetcher, "o/r", "1", types.GroupByNone, true, todotype.DefaultPolicy())
 		})
 		if !strings.Contains(out, wantLine) {
 			t.Fatalf("runMain(gha=true) output = %q, expected to contain %q", out, wantLine)
@@ -458,7 +459,7 @@ func TestRunFunctionsEmitWorkflowCommands(t *testing.T) {
 
 	t.Run("runMain does not emit when gha=false", func(t *testing.T) {
 		out, _, _ := captureAll(t, func() {
-			_, _ = runMain(fetcher, "o/r", "1", types.GroupByNone, false)
+			_, _ = runMain(fetcher, "o/r", "1", types.GroupByNone, false, todotype.DefaultPolicy())
 		})
 		if strings.Contains(out, "::notice ") || strings.Contains(out, "::warning ") || strings.Contains(out, "::error ") {
 			t.Fatalf("runMain(gha=false) unexpectedly emitted workflow command: %q", out)
@@ -468,7 +469,7 @@ func TestRunFunctionsEmitWorkflowCommands(t *testing.T) {
 	t.Run("runCount stdout stays plain", func(t *testing.T) {
 		t.Setenv("GITHUB_ACTIONS", "true")
 		out, _, _ := captureAll(t, func() {
-			_, _ = runCount(fetcher, "o/r", "1")
+			_, _ = runCount(fetcher, "o/r", "1", todotype.DefaultPolicy())
 		})
 		if strings.Contains(out, "::notice") || strings.Contains(out, "::warning") || strings.Contains(out, "::error") {
 			t.Fatalf("runCount must not emit workflow commands; got %q", out)
@@ -478,7 +479,7 @@ func TestRunFunctionsEmitWorkflowCommands(t *testing.T) {
 	t.Run("runNameOnly stdout stays plain", func(t *testing.T) {
 		t.Setenv("GITHUB_ACTIONS", "true")
 		out, _, _ := captureAll(t, func() {
-			_, _ = runNameOnly(fetcher, "o/r", "1")
+			_, _ = runNameOnly(fetcher, "o/r", "1", todotype.DefaultPolicy())
 		})
 		if strings.Contains(out, "::notice") || strings.Contains(out, "::warning") || strings.Contains(out, "::error") {
 			t.Fatalf("runNameOnly must not emit workflow commands; got %q", out)
@@ -572,7 +573,7 @@ index 0000000..1111111 100644
 			var result runResult
 			var gotErr error
 			_, _, _ = captureAll(t, func() {
-				result, gotErr = runMain(tt.fetcher, "o/r", "1", types.GroupByNone, false)
+				result, gotErr = runMain(tt.fetcher, "o/r", "1", types.GroupByNone, false, todotype.DefaultPolicy())
 			})
 			if gotErr != nil {
 				t.Fatalf("runMain() unexpected error = %v", gotErr)
@@ -589,7 +590,7 @@ index 0000000..1111111 100644
 			var result runResult
 			var gotErr error
 			_, _, _ = captureAll(t, func() {
-				result, gotErr = runCount(tt.fetcher, "o/r", "1")
+				result, gotErr = runCount(tt.fetcher, "o/r", "1", todotype.DefaultPolicy())
 			})
 			if gotErr != nil {
 				t.Fatalf("runCount() unexpected error = %v", gotErr)
@@ -606,7 +607,7 @@ index 0000000..1111111 100644
 			var result runResult
 			var gotErr error
 			_, _, _ = captureAll(t, func() {
-				result, gotErr = runNameOnly(tt.fetcher, "o/r", "1")
+				result, gotErr = runNameOnly(tt.fetcher, "o/r", "1", todotype.DefaultPolicy())
 			})
 			if gotErr != nil {
 				t.Fatalf("runNameOnly() unexpected error = %v", gotErr)
@@ -637,7 +638,7 @@ func TestRunFunctionsReturnZeroOnError(t *testing.T) {
 		var result runResult
 		var gotErr error
 		_, _, _ = captureAll(t, func() {
-			result, gotErr = runMain(fetcher, "", "", types.GroupByNone, false)
+			result, gotErr = runMain(fetcher, "", "", types.GroupByNone, false, todotype.DefaultPolicy())
 		})
 		if gotErr == nil {
 			t.Fatalf("runMain() expected error, got nil")
@@ -650,7 +651,7 @@ func TestRunFunctionsReturnZeroOnError(t *testing.T) {
 		var result runResult
 		var gotErr error
 		_, _, _ = captureAll(t, func() {
-			result, gotErr = runCount(fetcher, "", "")
+			result, gotErr = runCount(fetcher, "", "", todotype.DefaultPolicy())
 		})
 		if gotErr == nil {
 			t.Fatalf("runCount() expected error, got nil")
@@ -663,7 +664,7 @@ func TestRunFunctionsReturnZeroOnError(t *testing.T) {
 		var result runResult
 		var gotErr error
 		_, _, _ = captureAll(t, func() {
-			result, gotErr = runNameOnly(fetcher, "", "")
+			result, gotErr = runNameOnly(fetcher, "", "", todotype.DefaultPolicy())
 		})
 		if gotErr == nil {
 			t.Fatalf("runNameOnly() expected error, got nil")
@@ -684,6 +685,7 @@ func TestPrintUsage(t *testing.T) {
 		isHelp   bool
 		noCIFail bool
 		groupBy  = types.GroupByNone
+		sevFlag  = newSeverityFlag()
 	)
 	pflag.StringVarP(&repo, "repo", "R", "", "Select another repository using the [HOST/]OWNER/REPO format")
 	pflag.BoolVar(&nameOnly, "name-only", false, "Display only names of the files containing TODO comments")
@@ -691,6 +693,7 @@ func TestPrintUsage(t *testing.T) {
 	pflag.BoolVarP(&isHelp, "help", "h", false, "Display help information")
 	pflag.BoolVar(&noCIFail, "no-ci-fail", false, "Disable non-zero exit when error-level TODOs are found in CI")
 	pflag.Var(&groupBy, "group-by", "Group TODO comments by: \"file\" or \"type\"")
+	pflag.Var(sevFlag, "severity", "Override severity for one or more TODO types. Format: LEVEL=TYPE[,TYPE...] (e.g. --severity warning=TODO,HACK)")
 
 	var out string
 	stdout := captureStdout(t, func() {
@@ -716,6 +719,7 @@ func TestPrintUsage(t *testing.T) {
 		"--count",
 		"--help",
 		"--group-by",
+		"--severity",
 		"--no-ci-fail",
 		"ENVIRONMENT",
 		"CI",
@@ -724,10 +728,287 @@ func TestPrintUsage(t *testing.T) {
 		"By default, no built-in",
 		"keyword maps to error-level",
 		"--no-ci-fail",
+		"SEVERITY FLAG",
+		"LEVEL=TYPE[,TYPE...]",
+		"workflow annotation levels and CI exits",
+		"warning=TODO,HACK",
 	}
 	for _, want := range wantContain {
 		if !strings.Contains(out, want) {
 			t.Fatalf("printUsage() output = %q, expected to contain %q", out, want)
 		}
 	}
+}
+
+func TestSeverityFlagInvalid(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{name: "no equals sign", value: "warning"},
+		{name: "empty level", value: "=TODO"},
+		{name: "empty types", value: "warning="},
+		{name: "empty type in list", value: "warning=TODO,"},
+		{name: "type contains equals after level separator", value: "warning==TODO"},
+		{name: "type contains equals in list", value: "warning=TODO=FIXME"},
+		{name: "invalid severity", value: "invalid=TODO"},
+		{name: "unknown level", value: "critical=TODO"},
+		{name: "just equals", value: "="},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newSeverityFlag()
+			err := s.Set(tt.value)
+			if err == nil {
+				t.Fatalf("severityFlag.Set(%q) expected error, got nil", tt.value)
+			}
+		})
+	}
+}
+
+func TestSeverityFlagParsing(t *testing.T) {
+	t.Run("single type", func(t *testing.T) {
+		s := newSeverityFlag()
+		if err := s.Set("warning=TODO"); err != nil {
+			t.Fatalf("Set(warning=TODO) unexpected error: %v", err)
+		}
+		if got := s.assignments["TODO"]; got != todotype.SeverityWarning {
+			t.Fatalf("assignments[TODO] = %q, want %q", got, todotype.SeverityWarning)
+		}
+	})
+
+	t.Run("multiple types", func(t *testing.T) {
+		s := newSeverityFlag()
+		if err := s.Set("error=FIXME,BUG"); err != nil {
+			t.Fatalf("Set(error=FIXME,BUG) unexpected error: %v", err)
+		}
+		if got := s.assignments["FIXME"]; got != todotype.SeverityError {
+			t.Fatalf("assignments[FIXME] = %q, want %q", got, todotype.SeverityError)
+		}
+		if got := s.assignments["BUG"]; got != todotype.SeverityError {
+			t.Fatalf("assignments[BUG] = %q, want %q", got, todotype.SeverityError)
+		}
+	})
+
+	t.Run("last wins across repeated flags", func(t *testing.T) {
+		s := newSeverityFlag()
+		if err := s.Set("warning=TODO"); err != nil {
+			t.Fatalf("Set(warning=TODO) unexpected error: %v", err)
+		}
+		if err := s.Set("error=TODO"); err != nil {
+			t.Fatalf("Set(error=TODO) unexpected error: %v", err)
+		}
+		if got := s.assignments["TODO"]; got != todotype.SeverityError {
+			t.Fatalf("assignments[TODO] after last-wins = %q, want %q", got, todotype.SeverityError)
+		}
+	})
+
+	t.Run("type case normalization", func(t *testing.T) {
+		s := newSeverityFlag()
+		if err := s.Set("error=fixme"); err != nil {
+			t.Fatalf("Set(error=fixme) unexpected error: %v", err)
+		}
+		if got := s.assignments["FIXME"]; got != todotype.SeverityError {
+			t.Fatalf("assignments[FIXME] = %q, want %q", got, todotype.SeverityError)
+		}
+	})
+
+	t.Run("whitespace trimming", func(t *testing.T) {
+		s := newSeverityFlag()
+		if err := s.Set("  warning  =  TODO  ,  HACK  "); err != nil {
+			t.Fatalf("Set with whitespace unexpected error: %v", err)
+		}
+		if got := s.assignments["TODO"]; got != todotype.SeverityWarning {
+			t.Fatalf("assignments[TODO] with whitespace = %q, want %q", got, todotype.SeverityWarning)
+		}
+		if got := s.assignments["HACK"]; got != todotype.SeverityWarning {
+			t.Fatalf("assignments[HACK] with whitespace = %q, want %q", got, todotype.SeverityWarning)
+		}
+	})
+
+	t.Run("custom type", func(t *testing.T) {
+		s := newSeverityFlag()
+		if err := s.Set("warning=PERF"); err != nil {
+			t.Fatalf("Set(warning=PERF) unexpected error: %v", err)
+		}
+		if got := s.assignments["PERF"]; got != todotype.SeverityWarning {
+			t.Fatalf("assignments[PERF] = %q, want %q", got, todotype.SeverityWarning)
+		}
+	})
+
+	t.Run("severity case normalization", func(t *testing.T) {
+		s := newSeverityFlag()
+		if err := s.Set("WARNING=TODO"); err != nil {
+			t.Fatalf("Set(WARNING=TODO) unexpected error: %v", err)
+		}
+		if got := s.assignments["TODO"]; got != todotype.SeverityWarning {
+			t.Fatalf("assignments[TODO] = %q, want %q", got, todotype.SeverityWarning)
+		}
+
+		s2 := newSeverityFlag()
+		if err := s2.Set("Error=BUG"); err != nil {
+			t.Fatalf("Set(Error=BUG) unexpected error: %v", err)
+		}
+		if got := s2.assignments["BUG"]; got != todotype.SeverityError {
+			t.Fatalf("assignments[BUG] = %q, want %q", got, todotype.SeverityError)
+		}
+	})
+
+	t.Run("invalid input does not mutate existing assignments", func(t *testing.T) {
+		s := newSeverityFlag()
+		if err := s.Set("warning=TODO"); err != nil {
+			t.Fatalf("Set(warning=TODO) unexpected error: %v", err)
+		}
+		if err := s.Set("error=BUG,=FIXME"); err == nil {
+			t.Fatal("Set(error=BUG,=FIXME) expected error, got nil")
+		}
+		if got := s.assignments["TODO"]; got != todotype.SeverityWarning {
+			t.Fatalf("assignments[TODO] after invalid Set = %q, want %q", got, todotype.SeverityWarning)
+		}
+		if _, ok := s.assignments["BUG"]; ok {
+			t.Fatal("assignments[BUG] was added by invalid Set; want no mutation on error")
+		}
+	})
+}
+
+func TestSeverityOverrideAffectsCIFailCount(t *testing.T) {
+	fetcher := &stubFetcher{
+		diff:  sampleDiff,
+		files: map[string][]byte{"foo.go": []byte("package foo\n// TODO: add bar\n")},
+	}
+
+	t.Run("default policy TODO is notice → no CI fail", func(t *testing.T) {
+		var result runResult
+		var err error
+		_, _, _ = captureAll(t, func() {
+			result, err = runMain(fetcher, "o/r", "1", types.GroupByNone, false, todotype.DefaultPolicy())
+		})
+		if err != nil {
+			t.Fatalf("runMain() unexpected error = %v", err)
+		}
+		if result.ciFailingCount != 0 {
+			t.Fatalf("ciFailingCount = %d, want 0", result.ciFailingCount)
+		}
+	})
+
+	t.Run("TODO overridden to error affects all run modes", func(t *testing.T) {
+		policy := todotype.DefaultPolicy().WithSeverity("TODO", todotype.SeverityError)
+
+		var result runResult
+		var err error
+		_, _, _ = captureAll(t, func() {
+			result, err = runMain(fetcher, "o/r", "1", types.GroupByNone, false, policy)
+		})
+		if err != nil {
+			t.Fatalf("runMain() unexpected error = %v", err)
+		}
+		if result.ciFailingCount != 1 {
+			t.Fatalf("runMain() ciFailingCount = %d, want 1 (TODO overridden to error)", result.ciFailingCount)
+		}
+		if result.totalCount != 1 {
+			t.Fatalf("runMain() totalCount = %d, want 1", result.totalCount)
+		}
+
+		var countResult runResult
+		countOut, countStdout, countStderr := captureAll(t, func() {
+			countResult, err = runCount(fetcher, "o/r", "1", policy)
+		})
+		if err != nil {
+			t.Fatalf("runCount() unexpected error = %v", err)
+		}
+		assertSilentChannels(t, "runCount()", countStdout, countStderr)
+		if strings.TrimSpace(countOut) != "1" {
+			t.Fatalf("runCount() output = %q, want %q", countOut, "1")
+		}
+		if countResult.ciFailingCount != 1 {
+			t.Fatalf("runCount() ciFailingCount = %d, want 1 (TODO overridden to error)", countResult.ciFailingCount)
+		}
+
+		var nameOnlyResult runResult
+		nameOnlyOut, nameOnlyStdout, nameOnlyStderr := captureAll(t, func() {
+			nameOnlyResult, err = runNameOnly(fetcher, "o/r", "1", policy)
+		})
+		if err != nil {
+			t.Fatalf("runNameOnly() unexpected error = %v", err)
+		}
+		assertSilentChannels(t, "runNameOnly()", nameOnlyStdout, nameOnlyStderr)
+		if strings.TrimSpace(nameOnlyOut) != "foo.go" {
+			t.Fatalf("runNameOnly() output = %q, want %q", nameOnlyOut, "foo.go")
+		}
+		if nameOnlyResult.ciFailingCount != 1 {
+			t.Fatalf("runNameOnly() ciFailingCount = %d, want 1 (TODO overridden to error)", nameOnlyResult.ciFailingCount)
+		}
+	})
+
+	t.Run("TODO overridden to warning → no CI fail (warning is not error)", func(t *testing.T) {
+		policy := todotype.DefaultPolicy().WithSeverity("TODO", todotype.SeverityWarning)
+		var result runResult
+		var err error
+		_, _, _ = captureAll(t, func() {
+			result, err = runMain(fetcher, "o/r", "1", types.GroupByNone, false, policy)
+		})
+		if err != nil {
+			t.Fatalf("runMain() unexpected error = %v", err)
+		}
+		if result.ciFailingCount != 0 {
+			t.Fatalf("ciFailingCount = %d, want 0 (warning should not fail CI)", result.ciFailingCount)
+		}
+	})
+
+	t.Run("NOTE overridden to error → CI fail count is 1", func(t *testing.T) {
+		// NOTE is normally notice-level; override to error to trigger CI fail.
+		fetcher := &stubFetcher{
+			diff:  noteOnlyDiff,
+			files: map[string][]byte{"note.go": []byte("package note\n// NOTE: important note\n")},
+		}
+
+		policy := todotype.DefaultPolicy().WithSeverity("NOTE", todotype.SeverityError)
+		var result runResult
+		var err error
+		_, _, _ = captureAll(t, func() {
+			result, err = runMain(fetcher, "o/r", "1", types.GroupByNone, false, policy)
+		})
+		if err != nil {
+			t.Fatalf("runMain() unexpected error = %v", err)
+		}
+		if result.ciFailingCount != 1 {
+			t.Fatalf("ciFailingCount = %d, want 1 (NOTE overridden to error)", result.ciFailingCount)
+		}
+		if result.totalCount != 1 {
+			t.Fatalf("totalCount = %d, want 1", result.totalCount)
+		}
+	})
+}
+
+func TestSeverityOverrideAffectsWorkflowAnnotation(t *testing.T) {
+	fetcher := &stubFetcher{
+		diff:  sampleDiff,
+		files: map[string][]byte{"foo.go": []byte("package foo\n// TODO: add bar\n")},
+	}
+
+	t.Run("TODO overridden to warning → ::warning annotation", func(t *testing.T) {
+		policy := todotype.DefaultPolicy().WithSeverity("TODO", todotype.SeverityWarning)
+		out, _, _ := captureAll(t, func() {
+			_, _ = runMain(fetcher, "o/r", "1", types.GroupByNone, true, policy)
+		})
+		wantLine := "::warning file=foo.go,line=2,title=TODO::// TODO: add bar"
+		if !strings.Contains(out, wantLine) {
+			t.Fatalf("runMain output = %q, expected to contain %q", out, wantLine)
+		}
+		if strings.Contains(out, "::notice ") {
+			t.Fatalf("runMain output should not contain ::notice with warning override: %q", out)
+		}
+	})
+
+	t.Run("TODO overridden to error → ::error annotation", func(t *testing.T) {
+		policy := todotype.DefaultPolicy().WithSeverity("TODO", todotype.SeverityError)
+		out, _, _ := captureAll(t, func() {
+			_, _ = runMain(fetcher, "o/r", "1", types.GroupByNone, true, policy)
+		})
+		wantLine := "::error file=foo.go,line=2,title=TODO::// TODO: add bar"
+		if !strings.Contains(out, wantLine) {
+			t.Fatalf("runMain output = %q, expected to contain %q", out, wantLine)
+		}
+	})
 }

--- a/main_test.go
+++ b/main_test.go
@@ -728,7 +728,7 @@ func TestPrintUsage(t *testing.T) {
 		"By default, no built-in",
 		"keyword maps to error-level",
 		"--no-ci-fail",
-		"SEVERITY FLAG",
+		"SEVERITY OVERRIDES",
 		"LEVEL=TYPE[,TYPE...]",
 		"workflow annotation levels and CI exits",
 		"warning=TODO,HACK",


### PR DESCRIPTION
## Summary

- add repeatable `--severity LEVEL=TYPE[,TYPE...]` overrides to the CLI
- apply the resolved severity policy consistently to CI-failing counts and GitHub Actions annotations
- add validation/tests for malformed overrides and document the final help/README behavior
