### PR TITLE
feat(init): add init subcommand for config init

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,40 @@ gh pr-todo --severity warning=TODO,HACK --severity error=FIXME
 - `-h, --help`: Display help information
 - `--no-ci-fail`: Disable non-zero exit when error-level TODOs are found in CI (see below)
 
+### Initializing Configuration
+
+Use `gh pr-todo init` to create a default configuration file interactively:
+
+```bash
+gh pr-todo init
+```
+
+You will be prompted to choose a location for the config file:
+
+1. `.github/gh-pr-todo.yml` — repository-scoped config, created at the root of the current Git repository
+2. User config directory — global config, shared across all repos (typically `$XDG_CONFIG_HOME/gh-pr-todo/config.yml` on Linux, falling back to `~/.config/gh-pr-todo/config.yml`; actual path depends on your OS)
+
+If a config file already exists, `init` refuses to overwrite it unless `--force` is passed:
+
+```bash
+gh pr-todo init --force
+```
+
+The default configuration matches the runtime severity policy:
+
+```yaml
+severity:
+  notice:
+    - TODO
+    - NOTE
+  warning:
+    - FIXME
+    - HACK
+    - XXX
+    - BUG
+  error: []
+```
+
 ### Configuration File
 
 Severity overrides can be persisted in YAML configuration files. Config files use the following schema:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -87,13 +87,82 @@ func discoverRepoRoot(cwd string) (string, bool) {
 	return "", false
 }
 
+// DefaultConfigYAML returns the default configuration YAML content matching
+// the runtime default severity policy.
+func DefaultConfigYAML() []byte {
+	return []byte(`severity:
+  notice:
+    - TODO
+    - NOTE
+  warning:
+    - FIXME
+    - HACK
+    - XXX
+    - BUG
+  error: []
+`)
+}
+
+// GlobalPath returns the global config file path for the given user config
+// directory. Returns an error if userConfigDir is empty.
+func GlobalPath(userConfigDir string) (string, error) {
+	if userConfigDir == "" {
+		return "", fmt.Errorf("user config directory is empty")
+	}
+	return filepath.Join(userConfigDir, "gh-pr-todo", "config.yml"), nil
+}
+
+// RepoNarrowPath returns the path to .github/gh-pr-todo.yml at the root of
+// the repository containing cwd. Returns an error if cwd is not inside a
+// Git repository.
+func RepoNarrowPath(cwd string) (string, error) {
+	repoRoot, found := discoverRepoRoot(cwd)
+	if !found {
+		return "", fmt.Errorf("not inside a Git repository")
+	}
+	return filepath.Join(repoRoot, ".github", "gh-pr-todo.yml"), nil
+}
+
+// WriteDefault writes the default config YAML to path. If force is false,
+// it refuses to overwrite an existing file. Parent directories are created
+// as needed.
+func WriteDefault(path string, force bool) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("creating directory for %s: %w", path, err)
+	}
+
+	flags := os.O_WRONLY | os.O_CREATE
+	if force {
+		flags |= os.O_TRUNC
+	} else {
+		flags |= os.O_EXCL
+	}
+
+	f, err := os.OpenFile(path, flags, 0644)
+	if err != nil {
+		if os.IsExist(err) {
+			return fmt.Errorf("%s already exists; use --force to overwrite", path)
+		}
+		return fmt.Errorf("creating %s: %w", path, err)
+	}
+
+	if _, err := f.Write(DefaultConfigYAML()); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("writing %s: %w", path, err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("closing %s: %w", path, err)
+	}
+	return nil
+}
+
 // LoadGlobal loads the user-level config file.
 func LoadGlobal(userConfigDir string) (Config, error) {
 	merged := Config{Severities: make(map[string]todotype.Severity)}
-	if userConfigDir == "" {
+	globalPath, err := GlobalPath(userConfigDir)
+	if err != nil {
 		return merged, nil
 	}
-	globalPath := filepath.Join(userConfigDir, "gh-pr-todo", "config.yml")
 	if err := mergeFile(globalPath, &merged); err != nil {
 		return merged, err
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -170,6 +170,172 @@ func TestParse(t *testing.T) {
 	})
 }
 
+func TestDefaultConfigYAMLParsesToRuntimeDefaults(t *testing.T) {
+	t.Run("default YAML parses without error", func(t *testing.T) {
+		data := DefaultConfigYAML()
+		cfg, err := Parse(data, "default")
+		if err != nil {
+			t.Fatalf("Parse(DefaultConfigYAML()) unexpected error: %v", err)
+		}
+
+		// TODO and NOTE should be notice
+		if cfg.Severities["TODO"] != todotype.SeverityNotice {
+			t.Fatalf("expected TODO=notice, got %v", cfg.Severities["TODO"])
+		}
+		if cfg.Severities["NOTE"] != todotype.SeverityNotice {
+			t.Fatalf("expected NOTE=notice, got %v", cfg.Severities["NOTE"])
+		}
+
+		// FIXME, HACK, XXX, BUG should be warning
+		for _, typ := range []string{"FIXME", "HACK", "XXX", "BUG"} {
+			if cfg.Severities[typ] != todotype.SeverityWarning {
+				t.Fatalf("expected %s=warning, got %v", typ, cfg.Severities[typ])
+			}
+		}
+
+		// No type should have error severity
+		for typ, sev := range cfg.Severities {
+			if sev == todotype.SeverityError {
+				t.Fatalf("expected no error-level types in default, but %s is error", typ)
+			}
+		}
+	})
+}
+
+func TestGlobalPath(t *testing.T) {
+	t.Run("empty userConfigDir returns error", func(t *testing.T) {
+		_, err := GlobalPath("")
+		if err == nil {
+			t.Fatal("GlobalPath(\"\") expected error")
+		}
+	})
+
+	t.Run("valid userConfigDir returns path", func(t *testing.T) {
+		dir := t.TempDir()
+		path, err := GlobalPath(dir)
+		if err != nil {
+			t.Fatalf("GlobalPath(%q) unexpected error: %v", dir, err)
+		}
+		want := filepath.Join(dir, "gh-pr-todo", "config.yml")
+		if path != want {
+			t.Fatalf("GlobalPath(%q) = %q, want %q", dir, path, want)
+		}
+	})
+}
+
+func TestRepoNarrowPath(t *testing.T) {
+	t.Run("non-repo directory errors", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		_, err := RepoNarrowPath(tmpDir)
+		if err == nil {
+			t.Fatal("RepoNarrowPath() expected error for non-repo directory")
+		}
+	})
+
+	t.Run("repo root returns .github/gh-pr-todo.yml", func(t *testing.T) {
+		repoRoot := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(repoRoot, ".git"), 0755); err != nil {
+			t.Fatalf("MkdirAll() error: %v", err)
+		}
+		path, err := RepoNarrowPath(repoRoot)
+		if err != nil {
+			t.Fatalf("RepoNarrowPath() unexpected error: %v", err)
+		}
+		want := filepath.Join(repoRoot, ".github", "gh-pr-todo.yml")
+		if path != want {
+			t.Fatalf("RepoNarrowPath() = %q, want %q", path, want)
+		}
+	})
+
+	t.Run("nested subdirectory inside repo still returns root path", func(t *testing.T) {
+		repoRoot := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(repoRoot, ".git"), 0755); err != nil {
+			t.Fatalf("MkdirAll() error: %v", err)
+		}
+		subdir := filepath.Join(repoRoot, "a", "b", "c")
+		if err := os.MkdirAll(subdir, 0755); err != nil {
+			t.Fatalf("MkdirAll() error: %v", err)
+		}
+		path, err := RepoNarrowPath(subdir)
+		if err != nil {
+			t.Fatalf("RepoNarrowPath() unexpected error: %v", err)
+		}
+		want := filepath.Join(repoRoot, ".github", "gh-pr-todo.yml")
+		if path != want {
+			t.Fatalf("RepoNarrowPath() = %q, want %q", path, want)
+		}
+	})
+}
+
+func TestWriteDefault(t *testing.T) {
+	t.Run("creates file and parent directories", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		path := filepath.Join(tmpDir, "subdir", "config.yml")
+		if err := WriteDefault(path, false); err != nil {
+			t.Fatalf("WriteDefault() unexpected error: %v", err)
+		}
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("expected file to exist at %s: %v", path, err)
+		}
+		// Verify content is valid YAML
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("ReadFile() error: %v", err)
+		}
+		if _, err := Parse(data, path); err != nil {
+			t.Fatalf("Parse(written content) error: %v", err)
+		}
+	})
+
+	t.Run("refuses to overwrite without force", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		path := filepath.Join(tmpDir, "config.yml")
+		if err := WriteDefault(path, false); err != nil {
+			t.Fatalf("first WriteDefault() unexpected error: %v", err)
+		}
+		err := WriteDefault(path, false)
+		if err == nil {
+			t.Fatal("WriteDefault() without force expected error for existing file")
+		}
+		if !strings.Contains(err.Error(), "--force") {
+			t.Fatalf("WriteDefault() error = %q, expected to mention --force", err.Error())
+		}
+		// Content should be preserved
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("ReadFile() error: %v", err)
+		}
+		if _, err := Parse(data, path); err != nil {
+			t.Fatalf("Parse(preserved content) error: %v", err)
+		}
+	})
+
+	t.Run("overwrites with force", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		path := filepath.Join(tmpDir, "config.yml")
+		// Write original content
+		if err := os.WriteFile(path, []byte("original"), 0644); err != nil {
+			t.Fatalf("WriteFile() error: %v", err)
+		}
+		// Overwrite with force
+		if err := WriteDefault(path, true); err != nil {
+			t.Fatalf("WriteDefault(force=true) unexpected error: %v", err)
+		}
+		// Content should be the default YAML now
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("ReadFile() error: %v", err)
+		}
+		cfg, err := Parse(data, path)
+		if err != nil {
+			t.Fatalf("Parse(overwritten content) error: %v", err)
+		}
+		if cfg.Severities["TODO"] != todotype.SeverityNotice {
+			t.Fatalf("expected TODO=notice in overwritten file, got %v", cfg.Severities["TODO"])
+		}
+	})
+}
+
 func TestLoadGlobal(t *testing.T) {
 	t.Run("empty user config dir is treated as no global config", func(t *testing.T) {
 		cfg, err := LoadGlobal("")

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 	"net/url"
@@ -30,6 +31,46 @@ func registerFlags(fs *pflag.FlagSet, repo *string, nameOnly, isCount, isHelp, n
 }
 
 func main() {
+	// Check for init subcommand before the main pflag parsing, so "init"
+	// is not treated as a PR/branch argument.
+	if len(os.Args) > 1 && os.Args[1] == "init" {
+		initFS := pflag.NewFlagSet("gh pr-todo init", pflag.ContinueOnError)
+		initFS.SetOutput(io.Discard)
+
+		force := initFS.Bool("force", false, "Overwrite existing config file")
+		helpH := initFS.BoolP("help", "h", false, "Display help information")
+
+		if err := initFS.Parse(os.Args[2:]); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+
+		if *helpH {
+			printInitUsage(initFS)
+			os.Exit(0)
+		}
+
+		if initFS.NArg() > 0 {
+			fmt.Fprintln(os.Stderr, "gh pr-todo init: unexpected argument")
+			printInitUsage(initFS)
+			os.Exit(1)
+		}
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "Error getting current directory:", err)
+			os.Exit(1)
+		}
+
+		userConfigDir, _ := os.UserConfigDir()
+
+		if err := runInit(os.Stdin, color.Output, cwd, userConfigDir, *force); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+
 	// Use ContinueOnError so we can print a clear error and exit code 1
 	// instead of pflag's default ExitOnError (exit code 2).
 	pflag.CommandLine = pflag.NewFlagSet("gh pr-todo", pflag.ContinueOnError)
@@ -267,7 +308,11 @@ func resolveConfigTarget(repo, pr string) (string, string, bool) {
 func printUsage() {
 	fmt.Fprintf(color.Output, "%s\n\n", "View TODO-style comments in the PR diff.")
 	fmt.Fprintf(color.Output, "%s\n", output.Bold("USAGE"))
-	fmt.Fprintf(color.Output, "  %s\n\n", "gh pr-todo [<number> | <url> | <branch>] [flags]")
+	fmt.Fprintf(color.Output, "  %s\n", "gh pr-todo [<number> | <url> | <branch>] [flags]")
+	fmt.Fprintf(color.Output, "  %s\n\n", "gh pr-todo init [--force]")
+	fmt.Fprintf(color.Output, "%s\n", output.Bold("COMMANDS"))
+	fmt.Fprintf(color.Output, "  %s\n", "init    Create a default config file")
+	fmt.Fprintf(color.Output, "  %s\n\n", "        Run 'gh pr-todo init --help' for details.")
 	fmt.Fprintf(color.Output, "%s\n", output.Bold("FLAGS"))
 	maxLen := 0
 	pflag.VisitAll(func(f *pflag.Flag) {
@@ -368,4 +413,76 @@ func runNameOnly(fetcher ghclient.PRFetcher, repo, pr string, policy todotype.Po
 	}
 	output.PrintFileNames(todos)
 	return newRunResult(todos, policy), nil
+}
+
+func runInit(in io.Reader, out io.Writer, cwd, userConfigDir string, force bool) error {
+	repoPath, repoErr := config.RepoNarrowPath(cwd)
+	globalPath, globalErr := config.GlobalPath(userConfigDir)
+
+	fmt.Fprintln(out, "Choose config file location:")
+	if repoErr == nil {
+		fmt.Fprintln(out, "  1) .github/gh-pr-todo.yml")
+	} else {
+		fmt.Fprintln(out, "  1) .github/gh-pr-todo.yml (requires a Git repository)")
+	}
+	if globalErr == nil {
+		fmt.Fprintf(out, "  2) %s\n", globalPath)
+	} else {
+		fmt.Fprintln(out, "  2) user config directory not available")
+	}
+	fmt.Fprint(out, "Enter selection: ")
+
+	reader := bufio.NewReader(in)
+	line, err := reader.ReadString('\n')
+	if err != nil && (err != io.EOF || line == "") {
+		return fmt.Errorf("failed to read input: %w", err)
+	}
+	line = strings.TrimSpace(line)
+
+	var path string
+	switch line {
+	case "1":
+		if repoErr != nil {
+			return fmt.Errorf("repo config requires a Git repository")
+		}
+		path = repoPath
+	case "2":
+		if globalErr != nil || globalPath == "" {
+			return fmt.Errorf("user config directory not available")
+		}
+		path = globalPath
+	case "":
+		return fmt.Errorf("no input received")
+	default:
+		return fmt.Errorf("invalid selection %q: enter 1 or 2", line)
+	}
+
+	if err := config.WriteDefault(path, force); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(out, "Created %s\n", path)
+	return nil
+}
+
+func printInitUsage(fs *pflag.FlagSet) {
+	fmt.Fprintf(color.Output, "%s\n\n", "Create a default config file with interactive prompts.")
+	fmt.Fprintf(color.Output, "%s\n", output.Bold("USAGE"))
+	fmt.Fprintf(color.Output, "  %s\n\n", "gh pr-todo init [--force]")
+	fmt.Fprintf(color.Output, "%s\n", output.Bold("FLAGS"))
+	fs.VisitAll(func(f *pflag.Flag) {
+		if f.Shorthand != "" {
+			fmt.Fprintf(color.Output, "  -%s, --%s  %s\n", f.Shorthand, f.Name, f.Usage)
+		} else {
+			fmt.Fprintf(color.Output, "      --%s  %s\n", f.Name, f.Usage)
+		}
+	})
+	fmt.Fprintln(color.Output)
+	fmt.Fprintf(color.Output, "%s\n", output.Bold("DESCRIPTION"))
+	fmt.Fprintf(color.Output, "  %s\n", "Interactively creates a default configuration file at one of:")
+	fmt.Fprintf(color.Output, "  %s\n", "  - .github/gh-pr-todo.yml (repository scope)")
+	fmt.Fprintf(color.Output, "  %s\n", "  - user config dir/gh-pr-todo/config.yml (global scope)")
+	fmt.Fprintf(color.Output, "  %s\n", "")
+	fmt.Fprintf(color.Output, "  %s\n", "Use --force to overwrite an existing config file.")
+	fmt.Fprintln(color.Output)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -5,9 +5,11 @@ import (
 	"errors"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/Suree33/gh-pr-todo/internal/config"
 	"github.com/Suree33/gh-pr-todo/internal/todotype"
 	"github.com/Suree33/gh-pr-todo/pkg/types"
 	"github.com/fatih/color"
@@ -1049,6 +1051,178 @@ func TestSeverityOverrideAffectsWorkflowAnnotation(t *testing.T) {
 		wantLine := "::error file=foo.go,line=2,title=TODO::// TODO: add bar"
 		if !strings.Contains(out, wantLine) {
 			t.Fatalf("runMain output = %q, expected to contain %q", out, wantLine)
+		}
+	})
+}
+
+func TestRunInit(t *testing.T) {
+	t.Run("selection 1 creates repo config", func(t *testing.T) {
+		repoRoot := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(repoRoot, ".git"), 0755); err != nil {
+			t.Fatalf("MkdirAll() error: %v", err)
+		}
+
+		var buf bytes.Buffer
+		in := strings.NewReader("1\n")
+		err := runInit(in, &buf, repoRoot, t.TempDir(), false)
+		if err != nil {
+			t.Fatalf("runInit() unexpected error: %v", err)
+		}
+
+		wantPath := filepath.Join(repoRoot, ".github", "gh-pr-todo.yml")
+		if _, err := os.Stat(wantPath); err != nil {
+			t.Fatalf("expected file at %s: %v", wantPath, err)
+		}
+		if !strings.Contains(buf.String(), "Created") {
+			t.Fatalf("output = %q, expected success message", buf.String())
+		}
+	})
+
+	t.Run("selection 2 creates global config", func(t *testing.T) {
+		userConfigDir := t.TempDir()
+		var buf bytes.Buffer
+		in := strings.NewReader("2\n")
+		err := runInit(in, &buf, t.TempDir(), userConfigDir, false)
+		if err != nil {
+			t.Fatalf("runInit() unexpected error: %v", err)
+		}
+
+		wantPath := filepath.Join(userConfigDir, "gh-pr-todo", "config.yml")
+		if _, err := os.Stat(wantPath); err != nil {
+			t.Fatalf("expected file at %s: %v", wantPath, err)
+		}
+		if !strings.Contains(buf.String(), "Created") {
+			t.Fatalf("output = %q, expected success message", buf.String())
+		}
+	})
+
+	t.Run("selection without trailing newline is accepted", func(t *testing.T) {
+		userConfigDir := t.TempDir()
+		var buf bytes.Buffer
+		in := strings.NewReader("2")
+		err := runInit(in, &buf, t.TempDir(), userConfigDir, false)
+		if err != nil {
+			t.Fatalf("runInit() unexpected error: %v", err)
+		}
+
+		wantPath := filepath.Join(userConfigDir, "gh-pr-todo", "config.yml")
+		if _, err := os.Stat(wantPath); err != nil {
+			t.Fatalf("expected file at %s: %v", wantPath, err)
+		}
+	})
+
+	t.Run("existing file without force returns error", func(t *testing.T) {
+		repoRoot := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(repoRoot, ".git"), 0755); err != nil {
+			t.Fatalf("MkdirAll() error: %v", err)
+		}
+		// Create the config file first
+		configDir := filepath.Join(repoRoot, ".github")
+		if err := os.MkdirAll(configDir, 0755); err != nil {
+			t.Fatalf("MkdirAll() error: %v", err)
+		}
+		configPath := filepath.Join(configDir, "gh-pr-todo.yml")
+		if err := os.WriteFile(configPath, []byte("original"), 0644); err != nil {
+			t.Fatalf("WriteFile() error: %v", err)
+		}
+
+		var buf bytes.Buffer
+		in := strings.NewReader("1\n")
+		err := runInit(in, &buf, repoRoot, t.TempDir(), false)
+		if err == nil {
+			t.Fatal("runInit() expected error for existing file without force")
+		}
+		if !strings.Contains(err.Error(), "--force") {
+			t.Fatalf("runInit() error = %q, expected to mention --force", err.Error())
+		}
+		// Content preserved
+		data, err := os.ReadFile(configPath)
+		if err != nil {
+			t.Fatalf("ReadFile() error: %v", err)
+		}
+		if string(data) != "original" {
+			t.Fatalf("expected preserved content %q, got %q", "original", string(data))
+		}
+	})
+
+	t.Run("existing file with force overwrites", func(t *testing.T) {
+		repoRoot := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(repoRoot, ".git"), 0755); err != nil {
+			t.Fatalf("MkdirAll() error: %v", err)
+		}
+		// Create the config file first
+		configDir := filepath.Join(repoRoot, ".github")
+		if err := os.MkdirAll(configDir, 0755); err != nil {
+			t.Fatalf("MkdirAll() error: %v", err)
+		}
+		configPath := filepath.Join(configDir, "gh-pr-todo.yml")
+		if err := os.WriteFile(configPath, []byte("original"), 0644); err != nil {
+			t.Fatalf("WriteFile() error: %v", err)
+		}
+
+		var buf bytes.Buffer
+		in := strings.NewReader("1\n")
+		err := runInit(in, &buf, repoRoot, t.TempDir(), true)
+		if err != nil {
+			t.Fatalf("runInit() with force unexpected error: %v", err)
+		}
+		// Content should be default config now
+		data, err := os.ReadFile(configPath)
+		if err != nil {
+			t.Fatalf("ReadFile() error: %v", err)
+		}
+		cfg, err := config.Parse(data, configPath)
+		if err != nil {
+			t.Fatalf("Parse(overwritten) error: %v", err)
+		}
+		if cfg.Severities["TODO"] != todotype.SeverityNotice {
+			t.Fatalf("expected TODO=notice after overwrite, got %v", cfg.Severities["TODO"])
+		}
+	})
+
+	t.Run("invalid selection returns error", func(t *testing.T) {
+		var buf bytes.Buffer
+		in := strings.NewReader("3\n")
+		err := runInit(in, &buf, t.TempDir(), t.TempDir(), false)
+		if err == nil {
+			t.Fatal("runInit() expected error for invalid selection")
+		}
+		if !strings.Contains(err.Error(), "invalid selection") {
+			t.Fatalf("runInit() error = %q, expected 'invalid selection'", err.Error())
+		}
+	})
+
+	t.Run("EOF returns error", func(t *testing.T) {
+		var buf bytes.Buffer
+		in := strings.NewReader("") // EOF on first read
+		err := runInit(in, &buf, t.TempDir(), t.TempDir(), false)
+		if err == nil {
+			t.Fatal("runInit() expected error for EOF")
+		}
+	})
+
+	t.Run("empty input returns error", func(t *testing.T) {
+		var buf bytes.Buffer
+		in := strings.NewReader("\n") // Just newline = empty after trim
+		err := runInit(in, &buf, t.TempDir(), t.TempDir(), false)
+		if err == nil {
+			t.Fatal("runInit() expected error for empty input")
+		}
+		if !strings.Contains(err.Error(), "no input") {
+			t.Fatalf("runInit() error = %q, expected 'no input'", err.Error())
+		}
+	})
+
+	t.Run("local selection outside repo returns error", func(t *testing.T) {
+		var buf bytes.Buffer
+		in := strings.NewReader("1\n")
+		cwd := t.TempDir() // No .git directory
+		err := runInit(in, &buf, cwd, t.TempDir(), false)
+		if err == nil {
+			t.Fatal("runInit() expected error for local outside repo")
+		}
+		if !strings.Contains(err.Error(), "Git repository") {
+			t.Fatalf("runInit() error = %q, expected 'Git repository'", err.Error())
 		}
 	})
 }


### PR DESCRIPTION
## Summary

- Add `gh pr-todo init` to create a default config interactively
- Support repo-scoped and user config destinations
- Refuse overwrites unless `--force` is provided
- Document init behavior and add tests for config writing/input handling

Closes #84