### PR TITLE
feat(config): add ignored TODO marker types

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ gh pr-todo --group-by file
 # Override severities for one or more TODO types
 # Format: --severity LEVEL=TYPE[,TYPE...]
 gh pr-todo --severity warning=TODO,HACK --severity error=FIXME
+
+# Ignore specific marker types from detection (affects all output modes)
+gh pr-todo --ignore NOTE,HACK
 ```
 
 ### Command Options
@@ -76,6 +79,7 @@ gh pr-todo --severity warning=TODO,HACK --severity error=FIXME
 - `--name-only`: Display only names of the files containing TODO-style comments
 - `-c, --count`: Display only the number of TODO-style comments
 - `--severity LEVEL=TYPE[,TYPE...]`: Override severity for one or more TODO types; repeatable, whitespace-tolerant, and last assignment wins for duplicate types
+- `--ignore TYPE[,TYPE...]`: Ignore specified marker types; repeatable, case-insensitive, whitespace-tolerant. Ignored types are not detected or reported in any mode, including annotations and CI failure counts
 - `-h, --help`: Display help information
 - `--no-ci-fail`: Disable non-zero exit when error-level TODOs are found in CI (see below)
 
@@ -111,15 +115,18 @@ severity:
     - XXX
     - BUG
   error: []
+ignore: []
 ```
 
 ### Configuration File
 
-Severity overrides can be persisted in YAML configuration files. Config files use the following schema:
+Severity overrides and ignored types can be persisted in YAML configuration files. Config files use the following schema:
 
 ```yaml
 severity:
   notice|warning|error: [TYPE...]
+ignore:
+  - TYPE
 ```
 
 Example (`.github/gh-pr-todo.yml`):
@@ -130,32 +137,69 @@ severity:
     - TODO
   error:
     - FIXME
+ignore:
+  - NOTE
 ```
 
-#### Config File Paths
+#### Config File Paths and Precedence
 
-Config files are loaded from these locations in order of increasing precedence:
+Config files use **whole-file replacement** by precedence: each existing file replaces the entire previous configuration. This applies to both severity overrides and ignored types.
+
+Local files (in order of increasing precedence):
 
 1. User config dir `gh-pr-todo/config.yml` (global, shared across all repos; usually `~/.config/gh-pr-todo/config.yml` on Linux)
 2. `<repo>/.gh-pr-todo.yml` (repository root)
 3. `<repo>/.github/gh-pr-todo.yml` (narrower repo scope)
-4. CLI `--severity` flag (highest priority)
+4. CLI `--severity` and `--ignore` flags (highest priority)
 
-Each file's severity overrides are merged into the previous level. A more specific file overrides the same keys from a broader file. Unspecified keys keep their previous value.
+If a repo config file exists (root or `.github`), the global config is not applied. Within a repo, `.github/gh-pr-todo.yml` replaces `.gh-pr-todo.yml` entirely. CLI flags are applied on top of the resolved config.
 
 Configured TODO types are automatically detected in PR diffs alongside the built-in types. You can define custom types like `SECURITY` or `PERF` and they will be recognized.
 
 #### Remote Config Precedence
 
-When targeting another repository with `--repo` or a PR URL, local repository config files are replaced by remote configuration files with the following precedence (later wins):
+When targeting another repository with `--repo` or a PR URL, remote configuration is resolved with the following precedence:
 
-1. Global local config (user config dir `gh-pr-todo/config.yml`)
-2. Remote default branch config
-3. Remote PR base branch config
-4. Remote PR head branch config
-5. CLI `--severity` flag (highest priority)
+1. Remote PR head branch config
+2. Remote PR base branch config
+3. Remote default branch config
+4. Global local config, only when no remote config exists
+5. CLI `--severity` and `--ignore` flags (highest priority)
 
-For each remote scope, both `.gh-pr-todo.yml` and `.github/gh-pr-todo.yml` are checked (the narrower path wins within each scope).
+For each remote scope, `.github/gh-pr-todo.yml` replaces `.gh-pr-todo.yml` entirely. A remote config file replaces the global config entirely; global config is only used as a fallback when no remote config exists.
+
+#### Ignoring Marker Types
+
+The `ignore` config key lists marker types to exclude entirely from detection. Ignored types are not parsed or reported in any mode:
+
+- Default output
+- `--count`
+- `--name-only`
+- `--group-by file` or `--group-by type`
+- GitHub Actions annotations
+- CI failure counts
+
+Example:
+
+```yaml
+# .github/gh-pr-todo.yml
+severity:
+  warning:
+    - TODO
+  error:
+    - FIXME
+ignore:
+  - NOTE
+  - HACK
+```
+
+This config makes the tool ignore `NOTE` and `HACK` markers while still detecting `TODO` and `FIXME`. Ignored types can be built-in or custom and take precedence over severity: even if a type has `error` severity, ignoring it removes it from detection entirely.
+
+Use the CLI `--ignore` flag to extend the ignore set temporarily:
+
+```bash
+gh pr-todo --ignore NOTE,HACK
+```
 
 ### CI Mode
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,17 +13,20 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// Config holds parsed severity overrides from configuration files.
+// Config holds parsed severity overrides and ignored types from configuration files.
 type Config struct {
 	Severities map[string]todotype.Severity
+	Ignored    map[string]bool
+	Found      bool // true if at least one config file was found and parsed
 }
 
 // File represents the YAML configuration file schema.
 type File struct {
 	Severity map[string][]string `yaml:"severity"`
+	Ignore   []string            `yaml:"ignore"`
 }
 
-// Parse parses YAML config data and validates severity values.
+// Parse parses YAML config data and validates severity values and ignore list.
 // source is used in error messages to identify the file origin.
 func Parse(data []byte, source string) (Config, error) {
 	var f File
@@ -31,43 +34,58 @@ func Parse(data []byte, source string) (Config, error) {
 		return Config{}, fmt.Errorf("%s: invalid YAML: %w", source, err)
 	}
 
-	if len(f.Severity) == 0 {
-		return Config{Severities: make(map[string]todotype.Severity)}, nil
+	cfg := Config{Found: true}
+
+	// Parse severity overrides
+	if len(f.Severity) > 0 {
+		severities := make(map[string]todotype.Severity)
+		for levelStr, typeNames := range f.Severity {
+			normalizedLevel := strings.ToLower(strings.TrimSpace(levelStr))
+
+			var sev todotype.Severity
+			switch normalizedLevel {
+			case "notice":
+				sev = todotype.SeverityNotice
+			case "warning":
+				sev = todotype.SeverityWarning
+			case "error":
+				sev = todotype.SeverityError
+			default:
+				return Config{}, fmt.Errorf("%s: invalid severity key %q: allowed values are notice, warning, error",
+					source, levelStr)
+			}
+
+			for _, typeName := range typeNames {
+				normalizedType := strings.TrimSpace(typeName)
+				if normalizedType == "" {
+					return Config{}, fmt.Errorf("%s: type name is empty in severity %q", source, normalizedLevel)
+				}
+				normalizedType = strings.ToUpper(normalizedType)
+
+				if existingSev, exists := severities[normalizedType]; exists && existingSev != sev {
+					return Config{}, fmt.Errorf("%s: type %q appears under multiple severity levels (%s and %s)",
+						source, normalizedType, existingSev, sev)
+				}
+				severities[normalizedType] = sev
+			}
+		}
+		cfg.Severities = severities
 	}
 
-	severities := make(map[string]todotype.Severity)
-	for levelStr, typeNames := range f.Severity {
-		normalizedLevel := strings.ToLower(strings.TrimSpace(levelStr))
-
-		var sev todotype.Severity
-		switch normalizedLevel {
-		case "notice":
-			sev = todotype.SeverityNotice
-		case "warning":
-			sev = todotype.SeverityWarning
-		case "error":
-			sev = todotype.SeverityError
-		default:
-			return Config{}, fmt.Errorf("%s: invalid severity key %q: allowed values are notice, warning, error",
-				source, levelStr)
-		}
-
-		for _, typeName := range typeNames {
-			normalizedType := strings.TrimSpace(typeName)
-			if normalizedType == "" {
-				return Config{}, fmt.Errorf("%s: type name is empty in severity %q", source, normalizedLevel)
+	// Parse ignore list
+	if len(f.Ignore) > 0 {
+		ignored := make(map[string]bool)
+		for _, t := range f.Ignore {
+			normalized := strings.ToUpper(strings.TrimSpace(t))
+			if normalized == "" {
+				return Config{}, fmt.Errorf("%s: type name is empty in ignore list", source)
 			}
-			normalizedType = strings.ToUpper(normalizedType)
-
-			if existingSev, exists := severities[normalizedType]; exists && existingSev != sev {
-				return Config{}, fmt.Errorf("%s: type %q appears under multiple severity levels (%s and %s)",
-					source, normalizedType, existingSev, sev)
-			}
-			severities[normalizedType] = sev
+			ignored[normalized] = true
 		}
+		cfg.Ignored = ignored
 	}
 
-	return Config{Severities: severities}, nil
+	return cfg, nil
 }
 
 // discoverRepoRoot walks up from cwd looking for a .git directory or file.
@@ -100,6 +118,7 @@ func DefaultConfigYAML() []byte {
     - XXX
     - BUG
   error: []
+ignore: []
 `)
 }
 
@@ -156,70 +175,76 @@ func WriteDefault(path string, force bool) error {
 	return nil
 }
 
-// LoadGlobal loads the user-level config file.
+// LoadGlobal loads the user-level global config file if it exists.
+// Returns an empty/nil-map Config if the file does not exist.
 func LoadGlobal(userConfigDir string) (Config, error) {
-	merged := Config{Severities: make(map[string]todotype.Severity)}
+	if userConfigDir == "" {
+		return Config{}, nil
+	}
 	globalPath, err := GlobalPath(userConfigDir)
 	if err != nil {
-		return merged, nil
+		return Config{}, nil
 	}
-	if err := mergeFile(globalPath, &merged); err != nil {
-		return merged, err
+	data, err := os.ReadFile(globalPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return Config{}, nil
+		}
+		return Config{}, fmt.Errorf("reading %s: %w", globalPath, err)
 	}
-	return merged, nil
+	return Parse(data, globalPath)
 }
 
-// LoadLocal loads and merges config files from global and local paths.
-// cwd is the current working directory used to discover the repo root.
-// userConfigDir is typically os.UserConfigDir().
-//
-// Precedence (later wins): global < repo root .gh-pr-todo.yml < repo .github/gh-pr-todo.yml.
+// LoadLocal loads config from global, repo root, and repo .github paths
+// with whole-file replacement: each existing file replaces the entire
+// previous config. Precedence (later wins):
+// global < repo root .gh-pr-todo.yml < repo .github/gh-pr-todo.yml.
+// If any repo config exists, global content does not survive.
 // Missing files are silently ignored; parse errors are returned.
 func LoadLocal(cwd, userConfigDir string) (Config, error) {
-	merged, err := LoadGlobal(userConfigDir)
-	if err != nil {
-		return merged, err
-	}
-
-	// Repository root discovery
+	// Repository root discovery happens before global loading so repo config can
+	// replace global config without reading it at all.
 	repoRoot, found := discoverRepoRoot(cwd)
 	if !found {
-		return merged, nil
+		return LoadGlobal(userConfigDir)
 	}
 
-	// Repo root config: <repo>/.gh-pr-todo.yml
-	rootPath := filepath.Join(repoRoot, ".gh-pr-todo.yml")
-	if err := mergeFile(rootPath, &merged); err != nil {
-		return merged, err
-	}
-
-	// Narrower scope config: <repo>/.github/gh-pr-todo.yml
+	// Narrower scope config replaces the repo-root config entirely, so prefer it
+	// before reading or parsing the broader repo-root file.
 	narrowPath := filepath.Join(repoRoot, ".github", "gh-pr-todo.yml")
-	if err := mergeFile(narrowPath, &merged); err != nil {
-		return merged, err
+	cfg, exists, err := loadFile(narrowPath)
+	if err != nil {
+		return Config{}, err
+	}
+	if exists {
+		return cfg, nil
 	}
 
-	return merged, nil
+	rootPath := filepath.Join(repoRoot, ".gh-pr-todo.yml")
+	cfg, exists, err = loadFile(rootPath)
+	if err != nil {
+		return Config{}, err
+	}
+	if exists {
+		return cfg, nil
+	}
+
+	return LoadGlobal(userConfigDir)
 }
 
-// mergeFile reads a YAML config file at path and merges its severity
-// overrides into the target Config. Missing files are silently skipped.
-func mergeFile(path string, target *Config) error {
+// loadFile reads and parses a config file at path. Missing files return
+// exists=false and no error.
+func loadFile(path string) (Config, bool, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil
+			return Config{}, false, nil
 		}
-		return fmt.Errorf("reading %s: %w", path, err)
+		return Config{}, false, fmt.Errorf("reading %s: %w", path, err)
 	}
-
 	cfg, err := Parse(data, path)
 	if err != nil {
-		return err
+		return Config{}, true, err
 	}
-
-	for k, v := range cfg.Severities {
-		target.Severities[k] = v
-	}
-	return nil
+	return cfg, true, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -16,8 +16,14 @@ func TestParse(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Parse() unexpected error: %v", err)
 		}
-		if len(cfg.Severities) != 0 {
-			t.Fatalf("expected empty config, got %v", cfg.Severities)
+		if cfg.Severities != nil {
+			t.Fatalf("expected nil Severities, got %v", cfg.Severities)
+		}
+		if cfg.Ignored != nil {
+			t.Fatalf("expected nil Ignored, got %v", cfg.Ignored)
+		}
+		if !cfg.Found {
+			t.Fatal("expected Found=true after Parse")
 		}
 	})
 
@@ -26,8 +32,11 @@ func TestParse(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Parse() unexpected error: %v", err)
 		}
-		if len(cfg.Severities) != 0 {
-			t.Fatalf("expected empty config, got %v", cfg.Severities)
+		if cfg.Severities != nil {
+			t.Fatalf("expected nil Severities, got %v", cfg.Severities)
+		}
+		if cfg.Ignored != nil {
+			t.Fatalf("expected nil Ignored, got %v", cfg.Ignored)
 		}
 	})
 
@@ -44,6 +53,9 @@ func TestParse(t *testing.T) {
 		}
 		if !reflect.DeepEqual(cfg.Severities, want) {
 			t.Fatalf("Parse() = %v, want %v", cfg.Severities, want)
+		}
+		if !cfg.Found {
+			t.Fatal("expected Found=true")
 		}
 	})
 
@@ -168,6 +180,89 @@ func TestParse(t *testing.T) {
 			t.Fatal("Parse() expected error for case-insensitive duplicate type, got nil")
 		}
 	})
+
+	t.Run("ignore list parses to normalized set", func(t *testing.T) {
+		data := []byte("ignore:\n  - NOTE\n  - HACK\n  - todo\n")
+		cfg, err := Parse(data, "test")
+		if err != nil {
+			t.Fatalf("Parse() unexpected error: %v", err)
+		}
+		if len(cfg.Severities) != 0 {
+			t.Fatalf("expected no severities, got %v", cfg.Severities)
+		}
+		if !cfg.Ignored["NOTE"] || !cfg.Ignored["HACK"] || !cfg.Ignored["TODO"] {
+			t.Fatalf("expected ignored={NOTE,HACK,TODO}, got %v", cfg.Ignored)
+		}
+		// Should not have extra entries beyond what was specified
+		if len(cfg.Ignored) != 3 {
+			t.Fatalf("expected exactly 3 ignored types, got %v", cfg.Ignored)
+		}
+	})
+
+	t.Run("ignore list case normalization", func(t *testing.T) {
+		data := []byte("ignore:\n  - note\n  - Hack\n")
+		cfg, err := Parse(data, "test")
+		if err != nil {
+			t.Fatalf("Parse() unexpected error: %v", err)
+		}
+		if !cfg.Ignored["NOTE"] || !cfg.Ignored["HACK"] {
+			t.Fatalf("expected ignored={NOTE,HACK}, got %v", cfg.Ignored)
+		}
+	})
+
+	t.Run("empty ignore list results in nil map", func(t *testing.T) {
+		data := []byte("ignore: []")
+		cfg, err := Parse(data, "test")
+		if err != nil {
+			t.Fatalf("Parse() unexpected error: %v", err)
+		}
+		if cfg.Ignored != nil {
+			t.Fatalf("expected nil Ignored for empty list, got %v", cfg.Ignored)
+		}
+	})
+
+	t.Run("ignore with only severity has nil Ignored", func(t *testing.T) {
+		data := []byte("severity:\n  warning:\n    - TODO\n")
+		cfg, err := Parse(data, "test")
+		if err != nil {
+			t.Fatalf("Parse() unexpected error: %v", err)
+		}
+		if cfg.Ignored != nil {
+			t.Fatalf("expected nil Ignored when no ignore key, got %v", cfg.Ignored)
+		}
+		if cfg.Severities["TODO"] != todotype.SeverityWarning {
+			t.Fatalf("expected TODO=warning, got %v", cfg.Severities["TODO"])
+		}
+	})
+
+	t.Run("ignore empty type name returns error", func(t *testing.T) {
+		data := []byte("ignore:\n  - \"\"")
+		_, err := Parse(data, "test")
+		if err == nil || !strings.Contains(err.Error(), "type name is empty in ignore list") {
+			t.Fatalf("Parse() expected error for empty ignore type, got %v", err)
+		}
+	})
+
+	t.Run("error message for ignore includes source path", func(t *testing.T) {
+		_, err := Parse([]byte("ignore:\n  - \"\""), "/my/config.yml")
+		if err == nil || !strings.Contains(err.Error(), "/my/config.yml") {
+			t.Fatalf("Parse() error = %v, expected to contain source path", err)
+		}
+	})
+
+	t.Run("combination of severity and ignore", func(t *testing.T) {
+		data := []byte("severity:\n  warning:\n    - TODO\nignore:\n  - NOTE")
+		cfg, err := Parse(data, "test")
+		if err != nil {
+			t.Fatalf("Parse() unexpected error: %v", err)
+		}
+		if cfg.Severities["TODO"] != todotype.SeverityWarning {
+			t.Fatalf("expected TODO=warning, got %v", cfg.Severities["TODO"])
+		}
+		if !cfg.Ignored["NOTE"] {
+			t.Fatalf("expected NOTE ignored, got %v", cfg.Ignored)
+		}
+	})
 }
 
 func TestDefaultConfigYAMLParsesToRuntimeDefaults(t *testing.T) {
@@ -198,6 +293,11 @@ func TestDefaultConfigYAMLParsesToRuntimeDefaults(t *testing.T) {
 			if sev == todotype.SeverityError {
 				t.Fatalf("expected no error-level types in default, but %s is error", typ)
 			}
+		}
+
+		// ignore: [] should result in nil Ignored map (no ignored types)
+		if cfg.Ignored != nil {
+			t.Fatalf("expected nil Ignored for default config, got %v", cfg.Ignored)
 		}
 	})
 }
@@ -400,7 +500,7 @@ func TestLoadLocal(t *testing.T) {
 		}
 	})
 
-	t.Run("repo root config overrides global", func(t *testing.T) {
+	t.Run("repo root config replaces global entirely", func(t *testing.T) {
 		userConfigDir := t.TempDir()
 		globalDir := filepath.Join(userConfigDir, "gh-pr-todo")
 		if err := os.MkdirAll(globalDir, 0755); err != nil {
@@ -426,13 +526,40 @@ func TestLoadLocal(t *testing.T) {
 		if err != nil {
 			t.Fatalf("LoadLocal() unexpected error: %v", err)
 		}
-		// Global TODO=error overridden by repo TODO=warning
+		// Repo config replaces global entirely: only TODO=warning
 		if cfg.Severities["TODO"] != todotype.SeverityWarning {
-			t.Fatalf("expected TODO=warning (repo overrides global), got %v", cfg.Severities["TODO"])
+			t.Fatalf("expected TODO=warning (repo replaces global), got %v", cfg.Severities["TODO"])
 		}
-		// Global FIXME=notice preserved
-		if cfg.Severities["FIXME"] != todotype.SeverityNotice {
-			t.Fatalf("expected FIXME=notice (from global), got %v", cfg.Severities["FIXME"])
+		// FIXME from global should NOT survive whole-file replacement
+		if _, exists := cfg.Severities["FIXME"]; exists {
+			t.Fatalf("FIXME should not survive repo replacement, but got %v", cfg.Severities["FIXME"])
+		}
+	})
+
+	t.Run("invalid global config is not read when repo config exists", func(t *testing.T) {
+		userConfigDir := t.TempDir()
+		globalDir := filepath.Join(userConfigDir, "gh-pr-todo")
+		if err := os.MkdirAll(globalDir, 0755); err != nil {
+			t.Fatalf("MkdirAll() error: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(globalDir, "config.yml"), []byte("severity:\n  critical:\n    - TODO\n"), 0644); err != nil {
+			t.Fatalf("WriteFile() error: %v", err)
+		}
+
+		repoRoot := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(repoRoot, ".git"), 0755); err != nil {
+			t.Fatalf("MkdirAll() error: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(repoRoot, ".gh-pr-todo.yml"), []byte("severity:\n  warning:\n    - TODO\n"), 0644); err != nil {
+			t.Fatalf("WriteFile() error: %v", err)
+		}
+
+		cfg, err := LoadLocal(repoRoot, userConfigDir)
+		if err != nil {
+			t.Fatalf("LoadLocal() unexpected error: %v", err)
+		}
+		if cfg.Severities["TODO"] != todotype.SeverityWarning {
+			t.Fatalf("expected TODO=warning from repo config, got %v", cfg.Severities["TODO"])
 		}
 	})
 
@@ -475,6 +602,30 @@ func TestLoadLocal(t *testing.T) {
 		}
 		if cfg.Severities["TODO"] != todotype.SeverityError {
 			t.Fatalf("expected TODO=error (.github wins), got %v", cfg.Severities["TODO"])
+		}
+	})
+
+	t.Run("valid .github config replaces invalid root config", func(t *testing.T) {
+		repoRoot := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(repoRoot, ".git"), 0755); err != nil {
+			t.Fatalf("MkdirAll() error: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(repoRoot, ".gh-pr-todo.yml"), []byte("severity:\n  critical:\n    - TODO\n"), 0644); err != nil {
+			t.Fatalf("WriteFile() error: %v", err)
+		}
+		if err := os.MkdirAll(filepath.Join(repoRoot, ".github"), 0755); err != nil {
+			t.Fatalf("MkdirAll() error: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(repoRoot, ".github", "gh-pr-todo.yml"), []byte("severity:\n  error:\n    - TODO\n"), 0644); err != nil {
+			t.Fatalf("WriteFile() error: %v", err)
+		}
+
+		cfg, err := LoadLocal(repoRoot, t.TempDir())
+		if err != nil {
+			t.Fatalf("LoadLocal() unexpected error: %v", err)
+		}
+		if cfg.Severities["TODO"] != todotype.SeverityError {
+			t.Fatalf("expected TODO=error from .github config, got %v", cfg.Severities["TODO"])
 		}
 	})
 

--- a/internal/config/remote.go
+++ b/internal/config/remote.go
@@ -2,8 +2,6 @@ package config
 
 import (
 	"fmt"
-
-	"github.com/Suree33/gh-pr-todo/internal/todotype"
 )
 
 // RemoteConfigFetcher is the interface for fetching remote config files
@@ -26,58 +24,56 @@ type RemoteConfigRefs struct {
 	HeadRepo         string // e.g. "forkuser/repo" (empty if no PR)
 }
 
-// LoadRemote loads and merges config files from remote repository references.
-// Precedence within remote config (later wins): default branch < PR base < PR head.
-// The caller is responsible for applying global config before this result and
-// CLI overrides after it. For each scope, .gh-pr-todo.yml is loaded first, then
-// .github/gh-pr-todo.yml (narrower path wins within each scope).
+// LoadRemote loads config files from remote repository references.
+// Precedence: PR head > PR base > default branch. Within each scope,
+// .github/gh-pr-todo.yml replaces .gh-pr-todo.yml entirely.
 func LoadRemote(fetcher RemoteConfigFetcher, repo, pr string) (Config, error) {
-	merged := Config{Severities: make(map[string]todotype.Severity)}
-
 	refs, err := fetcher.FetchRemoteConfigRefs(repo, pr)
 	if err != nil {
-		return merged, fmt.Errorf("fetching remote refs: %w", err)
+		return Config{}, fmt.Errorf("fetching remote refs: %w", err)
 	}
 
-	// Helper to try loading both config paths at a given ref
-	loadRef := func(repoName, ref, scope string) error {
-		for _, path := range []string{".gh-pr-todo.yml", ".github/gh-pr-todo.yml"} {
-			data, found, err := fetcher.FetchFileAtRef(repoName, path, ref)
+	candidates := []struct {
+		repo  string
+		ref   string
+		scope string
+	}{
+		{repo: refs.HeadRepo, ref: refs.HeadRefOid, scope: "head"},
+		{repo: refs.BaseRepo, ref: refs.BaseBranchRef, scope: "base"},
+		{repo: refs.DefaultRepo, ref: refs.DefaultBranchRef, scope: "default"},
+	}
+
+	for _, candidate := range candidates {
+		if candidate.repo == "" || candidate.ref == "" {
+			continue
+		}
+
+		cfg, found, err := loadRemoteRef(fetcher, candidate.repo, candidate.ref, candidate.scope)
+		if err != nil {
+			return Config{}, err
+		}
+		if found {
+			return cfg, nil
+		}
+	}
+
+	return Config{}, nil
+}
+
+func loadRemoteRef(fetcher RemoteConfigFetcher, repoName, ref, scope string) (Config, bool, error) {
+	for _, path := range []string{".github/gh-pr-todo.yml", ".gh-pr-todo.yml"} {
+		data, found, err := fetcher.FetchFileAtRef(repoName, path, ref)
+		if err != nil {
+			return Config{}, false, fmt.Errorf("fetching %s from %s at %s (%s): %w", path, repoName, ref, scope, err)
+		}
+		if found {
+			source := fmt.Sprintf("%s:%s:%s", repoName, ref, path)
+			cfg, err := Parse(data, source)
 			if err != nil {
-				return fmt.Errorf("fetching %s from %s at %s (%s): %w", path, repoName, ref, scope, err)
+				return Config{}, true, err
 			}
-			if found {
-				source := fmt.Sprintf("%s:%s:%s", repoName, ref, path)
-				cfg, err := Parse(data, source)
-				if err != nil {
-					return err
-				}
-				for k, v := range cfg.Severities {
-					merged.Severities[k] = v
-				}
-			}
-		}
-		return nil
-	}
-
-	// Precedence: default branch < PR base < PR head
-	if refs.DefaultBranchRef != "" && refs.DefaultRepo != "" {
-		if err := loadRef(refs.DefaultRepo, refs.DefaultBranchRef, "default"); err != nil {
-			return merged, err
+			return cfg, true, nil
 		}
 	}
-
-	if refs.BaseBranchRef != "" && refs.BaseRepo != "" {
-		if err := loadRef(refs.BaseRepo, refs.BaseBranchRef, "base"); err != nil {
-			return merged, err
-		}
-	}
-
-	if refs.HeadRefOid != "" && refs.HeadRepo != "" {
-		if err := loadRef(refs.HeadRepo, refs.HeadRefOid, "head"); err != nil {
-			return merged, err
-		}
-	}
-
-	return merged, nil
+	return Config{}, false, nil
 }

--- a/internal/config/remote_test.go
+++ b/internal/config/remote_test.go
@@ -80,7 +80,7 @@ func TestLoadRemote(t *testing.T) {
 		}
 	})
 
-	t.Run("both paths loaded within scope", func(t *testing.T) {
+	t.Run(".github/gh-pr-todo.yml replaces .gh-pr-todo.yml within same scope", func(t *testing.T) {
 		fetcher := &fakeFetcher{
 			refs: RemoteConfigRefs{
 				DefaultBranchRef: "main",
@@ -97,13 +97,39 @@ func TestLoadRemote(t *testing.T) {
 		if err != nil {
 			t.Fatalf("LoadRemote() unexpected error: %v", err)
 		}
-		// .github/gh-pr-todo.yml wins within same scope
+		// .github/gh-pr-todo.yml replaces .gh-pr-todo.yml within scope
+		if cfg.Severities["TODO"] != todotype.SeverityWarning {
+			t.Fatalf("expected TODO=warning (.github wins), got %v", cfg.Severities)
+		}
+		// TODO=notice from .gh-pr-todo.yml should NOT survive
+		if len(cfg.Severities) != 1 {
+			t.Fatalf("expected exactly 1 severity (TODO=warning), got %v", cfg.Severities)
+		}
+	})
+
+	t.Run("valid .github config replaces invalid broad config within same scope", func(t *testing.T) {
+		fetcher := &fakeFetcher{
+			refs: RemoteConfigRefs{
+				DefaultBranchRef: "main",
+				DefaultRepo:      "owner/repo",
+			},
+			fileContents: map[string]map[string][]byte{
+				"owner/repo:main": {
+					".gh-pr-todo.yml":        []byte("severity:\n  critical:\n    - TODO\n"),
+					".github/gh-pr-todo.yml": []byte("severity:\n  warning:\n    - TODO\n"),
+				},
+			},
+		}
+		cfg, err := LoadRemote(fetcher, "owner/repo", "")
+		if err != nil {
+			t.Fatalf("LoadRemote() unexpected error: %v", err)
+		}
 		if cfg.Severities["TODO"] != todotype.SeverityWarning {
 			t.Fatalf("expected TODO=warning (.github wins), got %v", cfg.Severities)
 		}
 	})
 
-	t.Run("PR base overrides default, PR head overrides base", func(t *testing.T) {
+	t.Run("PR head replaces base replaces default (whole config)", func(t *testing.T) {
 		fetcher := &fakeFetcher{
 			refs: RemoteConfigRefs{
 				DefaultBranchRef: "main",
@@ -115,7 +141,7 @@ func TestLoadRemote(t *testing.T) {
 			},
 			fileContents: map[string]map[string][]byte{
 				"owner/repo:main": {
-					".github/gh-pr-todo.yml": []byte("severity:\n  notice:\n    - TODO\n"),
+					".github/gh-pr-todo.yml": []byte("severity:\n  notice:\n    - TODO\n  warning:\n    - FIXME\n"),
 				},
 				"owner/repo:release": {
 					".github/gh-pr-todo.yml": []byte("severity:\n  warning:\n    - TODO\n"),
@@ -129,9 +155,42 @@ func TestLoadRemote(t *testing.T) {
 		if err != nil {
 			t.Fatalf("LoadRemote() unexpected error: %v", err)
 		}
-		// Head wins
+		// Head replaces base which replaced default: only TODO=error, no FIXME
 		if cfg.Severities["TODO"] != todotype.SeverityError {
 			t.Fatalf("expected TODO=error (head wins), got %v", cfg.Severities)
+		}
+		// FIXME from default should NOT survive head replacement
+		if _, exists := cfg.Severities["FIXME"]; exists {
+			t.Fatalf("FIXME should not survive head replacement, but got %v", cfg.Severities["FIXME"])
+		}
+		if len(cfg.Severities) != 1 {
+			t.Fatalf("expected exactly 1 severity (TODO=error), got %v", cfg.Severities)
+		}
+	})
+
+	t.Run("valid head config replaces invalid default config", func(t *testing.T) {
+		fetcher := &fakeFetcher{
+			refs: RemoteConfigRefs{
+				DefaultBranchRef: "main",
+				DefaultRepo:      "owner/repo",
+				HeadRefOid:       "abc123",
+				HeadRepo:         "forkuser/repo",
+			},
+			fileContents: map[string]map[string][]byte{
+				"owner/repo:main": {
+					".github/gh-pr-todo.yml": []byte("severity:\n  critical:\n    - TODO\n"),
+				},
+				"forkuser/repo:abc123": {
+					".github/gh-pr-todo.yml": []byte("severity:\n  error:\n    - TODO\n"),
+				},
+			},
+		}
+		cfg, err := LoadRemote(fetcher, "owner/repo", "42")
+		if err != nil {
+			t.Fatalf("LoadRemote() unexpected error: %v", err)
+		}
+		if cfg.Severities["TODO"] != todotype.SeverityError {
+			t.Fatalf("expected TODO=error from head config, got %v", cfg.Severities)
 		}
 	})
 

--- a/internal/output/workflow.go
+++ b/internal/output/workflow.go
@@ -15,6 +15,9 @@ import (
 // See https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands
 func PrintWorkflowCommands(todos []types.TODO, policy todotype.Policy) {
 	for _, todo := range todos {
+		if policy.IsIgnored(todo.Type) {
+			continue
+		}
 		fmt.Fprintf(color.Output, "::%s file=%s,line=%d,title=%s::%s\n",
 			workflowCommandFor(todo.Type, policy),
 			escapeWorkflowProperty(todo.Filename),

--- a/internal/output/workflow_test.go
+++ b/internal/output/workflow_test.go
@@ -51,6 +51,25 @@ func TestPrintWorkflowCommandsWithPolicy(t *testing.T) {
 	}
 }
 
+func TestPrintWorkflowCommandsSkipsIgnoredTypes(t *testing.T) {
+	policy := todotype.DefaultPolicy().WithSeverity("SECURITY", todotype.SeverityError).WithIgnoredTypes([]string{"NOTE", "SECURITY"})
+
+	todos := []types.TODO{
+		{Filename: "a.go", Line: 5, Comment: "// TODO: a", Type: "TODO"},
+		{Filename: "b.go", Line: 20, Comment: "// NOTE: b", Type: "NOTE"},
+		{Filename: "c.go", Line: 30, Comment: "// SECURITY: c", Type: "SECURITY"},
+	}
+
+	want := "::notice file=a.go,line=5,title=TODO::// TODO: a\n"
+
+	got := captureOutput(t, func() {
+		PrintWorkflowCommands(todos, policy)
+	})
+	if got != want {
+		t.Fatalf("PrintWorkflowCommands() with ignored types output mismatch\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
 func TestPrintWorkflowCommandsAppliesEscaping(t *testing.T) {
 	todos := []types.TODO{
 		{

--- a/internal/todotype/todotype.go
+++ b/internal/todotype/todotype.go
@@ -23,6 +23,7 @@ const (
 type Policy struct {
 	severityByType      map[string]Severity
 	ciFailingSeverities map[Severity]bool
+	ignoredTypes        map[string]bool
 }
 
 // DefaultPolicy returns the default TODO type policy.
@@ -50,6 +51,7 @@ func (p Policy) WithSeverities(overrides map[string]Severity) Policy {
 	clone := Policy{
 		severityByType:      make(map[string]Severity, len(p.severityByType)+len(overrides)),
 		ciFailingSeverities: make(map[Severity]bool, len(p.ciFailingSeverities)),
+		ignoredTypes:        make(map[string]bool, len(p.ignoredTypes)),
 	}
 	for todoType, severity := range p.severityByType {
 		clone.severityByType[todoType] = severity
@@ -57,8 +59,32 @@ func (p Policy) WithSeverities(overrides map[string]Severity) Policy {
 	for severity, failing := range p.ciFailingSeverities {
 		clone.ciFailingSeverities[severity] = failing
 	}
+	for t := range p.ignoredTypes {
+		clone.ignoredTypes[t] = true
+	}
 	for todoType, severity := range overrides {
 		clone.severityByType[normalizeTodoType(todoType)] = severity
+	}
+	return clone
+}
+
+// WithIgnoredTypes returns a copy of the policy with the ignored type set
+// replaced by the given types. Ignored types are excluded from Types() and
+// therefore from detection, output, annotations, and CI failure counts.
+func (p Policy) WithIgnoredTypes(types []string) Policy {
+	clone := Policy{
+		severityByType:      make(map[string]Severity, len(p.severityByType)),
+		ciFailingSeverities: make(map[Severity]bool, len(p.ciFailingSeverities)),
+		ignoredTypes:        make(map[string]bool, len(types)),
+	}
+	for todoType, severity := range p.severityByType {
+		clone.severityByType[todoType] = severity
+	}
+	for severity, failing := range p.ciFailingSeverities {
+		clone.ciFailingSeverities[severity] = failing
+	}
+	for _, t := range types {
+		clone.ignoredTypes[normalizeTodoType(t)] = true
 	}
 	return clone
 }
@@ -72,10 +98,18 @@ func (p Policy) SeverityFor(todoType string) Severity {
 	return severity
 }
 
+// IsIgnored reports whether a TODO type is excluded from detection and reporting.
+func (p Policy) IsIgnored(todoType string) bool {
+	return p.ignoredTypes[normalizeTodoType(todoType)]
+}
+
 // IsCIFailing reports whether a TODO of the given type should cause a
-// non-zero exit in CI. By default, only error-level types fail;
-// warning-level and notice-level types do not.
+// non-zero exit in CI. Ignored types never fail CI. By default, only
+// error-level types fail; warning-level and notice-level types do not.
 func (p Policy) IsCIFailing(todoType string) bool {
+	if p.IsIgnored(todoType) {
+		return false
+	}
 	return p.ciFailingSeverities[p.SeverityFor(todoType)]
 }
 
@@ -101,16 +135,22 @@ func DefaultTypes() []string {
 	return result
 }
 
-// Types returns all TODO marker types known to this policy, including
-// built-in markers and any custom types added via severity overrides.
+// Types returns all TODO marker types known to this policy, excluding
+// ignored types. Built-in markers and custom types added via severity
+// overrides are included unless they are in the ignored set.
 // The result is sorted alphabetically and normalized to uppercase.
 func (p Policy) Types() []string {
 	typeSet := make(map[string]bool)
 	for _, t := range defaultTypes {
-		typeSet[t] = true
+		if !p.ignoredTypes[t] {
+			typeSet[t] = true
+		}
 	}
 	for t := range p.severityByType {
-		typeSet[normalizeTodoType(t)] = true
+		normalized := normalizeTodoType(t)
+		if !p.ignoredTypes[normalized] {
+			typeSet[normalized] = true
+		}
 	}
 	result := make([]string, 0, len(typeSet))
 	for t := range typeSet {

--- a/internal/todotype/todotype_test.go
+++ b/internal/todotype/todotype_test.go
@@ -290,6 +290,22 @@ func TestPolicyCountCIFailingWithOverrides(t *testing.T) {
 			t.Fatalf("CountCIFailing() = %d, want 1", got)
 		}
 	})
+
+	t.Run("ignored error severity type does not fail CI", func(t *testing.T) {
+		p := DefaultPolicy().WithSeverity("OPTIMIZE", SeverityError).WithIgnoredTypes([]string{"OPTIMIZE"})
+		todos := []types.TODO{
+			{Type: "OPTIMIZE"},
+		}
+		if !p.IsIgnored("OPTIMIZE") {
+			t.Fatal("IsIgnored(OPTIMIZE) should be true")
+		}
+		if p.IsCIFailing("OPTIMIZE") {
+			t.Fatal("IsCIFailing(OPTIMIZE) should be false for ignored type")
+		}
+		if got := p.CountCIFailing(todos); got != 0 {
+			t.Fatalf("CountCIFailing() = %d, want 0", got)
+		}
+	})
 }
 
 func TestPackageLevelFunctionsUseDefaultPolicy(t *testing.T) {
@@ -352,4 +368,58 @@ func TestPolicyTypes(t *testing.T) {
 		}
 	})
 
+	t.Run("ignored built-in types excluded", func(t *testing.T) {
+		p := DefaultPolicy().WithIgnoredTypes([]string{"NOTE", "HACK"})
+		got := p.Types()
+		want := []string{"BUG", "FIXME", "TODO", "XXX"}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("Types() = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("ignored custom severity types excluded", func(t *testing.T) {
+		p := DefaultPolicy().WithSeverity("REVIEW", SeverityWarning).WithIgnoredTypes([]string{"REVIEW"})
+		got := p.Types()
+		want := []string{"BUG", "FIXME", "HACK", "NOTE", "TODO", "XXX"}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("Types() = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("ignored types case-insensitive", func(t *testing.T) {
+		p := DefaultPolicy().WithIgnoredTypes([]string{"note", "Hack"})
+		got := p.Types()
+		want := []string{"BUG", "FIXME", "TODO", "XXX"}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("Types() = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("ignored types override severity additions", func(t *testing.T) {
+		p := DefaultPolicy().WithSeverity("SECURITY", SeverityError).WithIgnoredTypes([]string{"SECURITY"})
+		got := p.Types()
+		want := []string{"BUG", "FIXME", "HACK", "NOTE", "TODO", "XXX"}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("Types() = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("immutability: original policy unchanged after WithIgnoredTypes", func(t *testing.T) {
+		orig := DefaultPolicy()
+		_ = orig.WithIgnoredTypes([]string{"NOTE"})
+		got := orig.Types()
+		want := []string{"BUG", "FIXME", "HACK", "NOTE", "TODO", "XXX"}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("original Types() = %v, want %v (unchanged)", got, want)
+		}
+	})
+
+	t.Run("WithSeverities preserves ignored types", func(t *testing.T) {
+		p := DefaultPolicy().WithIgnoredTypes([]string{"NOTE"}).WithSeverity("TODO", SeverityWarning)
+		got := p.Types()
+		want := []string{"BUG", "FIXME", "HACK", "TODO", "XXX"}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("Types() = %v, want %v (NOTE ignored even after WithSeverity)", got, want)
+		}
+	})
 }

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spf13/pflag"
 )
 
-func registerFlags(fs *pflag.FlagSet, repo *string, nameOnly, isCount, isHelp, noCIFail *bool, groupBy *types.GroupBy, sevFlag *severityFlag) {
+func registerFlags(fs *pflag.FlagSet, repo *string, nameOnly, isCount, isHelp, noCIFail *bool, groupBy *types.GroupBy, sevFlag *severityFlag, ignoreFlag *ignoreFlag) {
 	fs.StringVarP(repo, "repo", "R", "", "Select another repository using the [HOST/]OWNER/REPO format")
 	fs.BoolVar(nameOnly, "name-only", false, "Display only names of the files containing TODO-style comments")
 	fs.BoolVarP(isCount, "count", "c", false, "Display only the number of TODO-style comments")
@@ -28,6 +28,7 @@ func registerFlags(fs *pflag.FlagSet, repo *string, nameOnly, isCount, isHelp, n
 	fs.BoolVar(noCIFail, "no-ci-fail", false, "Disable non-zero exit when error-level TODOs are found in CI")
 	fs.Var(groupBy, "group-by", "Group TODO-style comments by: \"file\" or \"type\"")
 	fs.Var(sevFlag, "severity", "Override severity for one or more TODO types. Format: LEVEL=TYPE[,TYPE...] (e.g. --severity warning=TODO,HACK)")
+	fs.Var(ignoreFlag, "ignore", "Ignore specified TODO marker types (comma-separated, repeatable). These types are not detected or reported. Example: --ignore NOTE,HACK")
 }
 
 func main() {
@@ -84,8 +85,9 @@ func main() {
 		noCIFail bool
 		groupBy  = types.GroupByNone
 		sevFlag  = newSeverityFlag()
+		ignFlag  = newIgnoreFlag()
 	)
-	registerFlags(pflag.CommandLine, &repo, &nameOnly, &isCount, &isHelp, &noCIFail, &groupBy, sevFlag)
+	registerFlags(pflag.CommandLine, &repo, &nameOnly, &isCount, &isHelp, &noCIFail, &groupBy, sevFlag, ignFlag)
 	pflag.Usage = printUsage
 	if err := pflag.CommandLine.Parse(os.Args[1:]); err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -117,6 +119,7 @@ func main() {
 
 	// Build policy with config and CLI overrides.
 	// Precedence: default < config < CLI.
+	// CLI ignore and severity have highest priority.
 	policy := todotype.DefaultPolicy()
 
 	userConfigDir := ""
@@ -131,20 +134,21 @@ func main() {
 		err error
 	)
 	if useRemoteConfig {
-		cfg, err = config.LoadGlobal(userConfigDir)
-		if err != nil {
-			fmt.Fprintln(os.Stderr, "Config error:", err)
-			os.Exit(1)
-		}
-		if len(cfg.Severities) > 0 {
-			policy = policy.WithSeverities(cfg.Severities)
-		}
-
 		fetcher := ghclient.NewClient()
-		cfg, err = config.LoadRemote(fetcher, configRepo, configPR)
+		remoteCfg, err := config.LoadRemote(fetcher, configRepo, configPR)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "Remote config error:", err)
 			os.Exit(1)
+		}
+
+		if remoteCfg.Found {
+			cfg = remoteCfg
+		} else {
+			cfg, err = config.LoadGlobal(userConfigDir)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, "Config error:", err)
+				os.Exit(1)
+			}
 		}
 	} else {
 		cwd, err := os.Getwd()
@@ -158,12 +162,31 @@ func main() {
 			os.Exit(1)
 		}
 	}
+
+	// Apply severity overrides from config
 	if len(cfg.Severities) > 0 {
 		policy = policy.WithSeverities(cfg.Severities)
 	}
 
+	// Apply CLI severity overrides (highest priority)
 	if len(sevFlag.assignments) > 0 {
 		policy = policy.WithSeverities(sevFlag.assignments)
+	}
+
+	// Collect all ignored types from config and CLI, then apply together
+	ignoredSet := make(map[string]bool)
+	for t := range cfg.Ignored {
+		ignoredSet[t] = true
+	}
+	for _, t := range ignFlag.types {
+		ignoredSet[t] = true
+	}
+	if len(ignoredSet) > 0 {
+		ignored := make([]string, 0, len(ignoredSet))
+		for t := range ignoredSet {
+			ignored = append(ignored, t)
+		}
+		policy = policy.WithIgnoredTypes(ignored)
 	}
 
 	fetcher := ghclient.NewClient()
@@ -252,6 +275,36 @@ func (s *severityFlag) Set(val string) error {
 }
 
 func (s *severityFlag) Type() string { return "severity" }
+
+// ignoreFlag accumulates --ignore TYPE[,TYPE...] flag values.
+// Each flag adds one or more type names to the ignore set.
+type ignoreFlag struct {
+	types []string
+}
+
+func newIgnoreFlag() *ignoreFlag {
+	return &ignoreFlag{}
+}
+
+func (f *ignoreFlag) String() string {
+	return strings.Join(f.types, ",")
+}
+
+func (f *ignoreFlag) Set(val string) error {
+	for _, typ := range strings.Split(val, ",") {
+		t := strings.TrimSpace(typ)
+		if t == "" {
+			return fmt.Errorf("invalid --ignore %q: type name is empty", val)
+		}
+		if strings.ContainsRune(t, '=') {
+			return fmt.Errorf("invalid --ignore %q: type name %q must not contain '='", val, t)
+		}
+		f.types = append(f.types, strings.ToUpper(t))
+	}
+	return nil
+}
+
+func (f *ignoreFlag) Type() string { return "ignore" }
 
 // newRunResult computes a runResult from a TODO slice using the given policy.
 func newRunResult(todos []types.TODO, policy todotype.Policy) runResult {
@@ -344,24 +397,33 @@ func printUsage() {
 	fmt.Fprintf(color.Output, "  %s\n", "Use --severity LEVEL=TYPE[,TYPE...] to override severities.")
 	fmt.Fprintf(color.Output, "  %s\n", "Affects workflow annotation levels and CI exits for error-level types.")
 	fmt.Fprintf(color.Output, "  %s\n\n", "Example: --severity warning=TODO,HACK --severity error=FIXME")
+	fmt.Fprintf(color.Output, "%s\n", output.Bold("IGNORE TYPES"))
+	fmt.Fprintf(color.Output, "  %s\n", "Use --ignore TYPE[,TYPE...] to exclude marker types from detection.")
+	fmt.Fprintf(color.Output, "  %s\n", "Ignored types are not parsed or reported in any mode (default output,")
+	fmt.Fprintf(color.Output, "  %s\n", "--count, --name-only, --group-by, annotations, CI failure counts).")
+	fmt.Fprintf(color.Output, "  %s\n\n", "Example: --ignore NOTE,HACK")
 	fmt.Fprintf(color.Output, "%s\n", output.Bold("CONFIGURATION"))
-	fmt.Fprintf(color.Output, "  %s\n", "Severity overrides can be configured in YAML config files.")
+	fmt.Fprintf(color.Output, "  %s\n", "Severity overrides and ignored types can be configured in YAML config files.")
 	fmt.Fprintf(color.Output, "  %s\n", "Configured custom types are detected alongside the built-in markers.")
-	fmt.Fprintf(color.Output, "  %s\n", "Schema: severity:\n    notice|warning|error: [TYPE...]")
+	fmt.Fprintf(color.Output, "  %s\n", "Schema:")
+	fmt.Fprintf(color.Output, "  %s\n", "  severity:")
+	fmt.Fprintf(color.Output, "  %s\n", "    notice|warning|error: [TYPE...]")
+	fmt.Fprintf(color.Output, "  %s\n", "  ignore:")
+	fmt.Fprintf(color.Output, "  %s\n", "    - TYPE")
 	fmt.Fprintf(color.Output, "  %s\n", "Empty lists are allowed and ignored; a type may not appear under multiple severity levels.")
-	fmt.Fprintf(color.Output, "  %s\n", "Config file paths and precedence (later wins):")
+	fmt.Fprintf(color.Output, "  %s\n", "Config file paths and precedence (each existing file replaces earlier ones):")
 	fmt.Fprintf(color.Output, "  %s\n", "  1. user config dir/gh-pr-todo/config.yml (global)")
 	fmt.Fprintf(color.Output, "  %s\n", "  2. <repo>/.gh-pr-todo.yml (repo root)")
 	fmt.Fprintf(color.Output, "  %s\n", "  3. <repo>/.github/gh-pr-todo.yml (narrower repo config)")
-	fmt.Fprintf(color.Output, "  %s\n", "  4. CLI --severity flag (highest priority)")
+	fmt.Fprintf(color.Output, "  %s\n", "  4. CLI --severity and --ignore flags (highest priority)")
 	fmt.Fprintf(color.Output, "  %s\n", "When targeting another repository with --repo or a PR URL,")
-	fmt.Fprintf(color.Output, "  %s\n", "repo-local configs are replaced by remote configs:")
-	fmt.Fprintf(color.Output, "  %s\n", "  1. global config")
-	fmt.Fprintf(color.Output, "  %s\n", "  2. remote default branch config")
-	fmt.Fprintf(color.Output, "  %s\n", "  3. remote PR base branch config")
-	fmt.Fprintf(color.Output, "  %s\n", "  4. remote PR head branch config")
-	fmt.Fprintf(color.Output, "  %s\n", "  5. CLI --severity flag (highest priority)")
-	fmt.Fprintf(color.Output, "  %s\n\n", "Example config:\n# .github/gh-pr-todo.yml\nseverity:\n  warning:\n    - TODO\n  error:\n    - FIXME")
+	fmt.Fprintf(color.Output, "  %s\n", "remote config replaces global config when found:")
+	fmt.Fprintf(color.Output, "  %s\n", "  1. remote PR head branch config")
+	fmt.Fprintf(color.Output, "  %s\n", "  2. remote PR base branch config")
+	fmt.Fprintf(color.Output, "  %s\n", "  3. remote default branch config")
+	fmt.Fprintf(color.Output, "  %s\n", "  4. global config (fallback only when no remote config exists)")
+	fmt.Fprintf(color.Output, "  %s\n", "  5. CLI --severity and --ignore flags (highest priority)")
+	fmt.Fprintf(color.Output, "  %s\n\n", "Example config:  # .github/gh-pr-todo.yml\nseverity:\n  warning:\n    - TODO\n  error:\n    - FIXME\nignore:\n  - NOTE")
 }
 
 func runMain(fetcher ghclient.PRFetcher, repo, pr string, groupBy types.GroupBy, gha bool, policy todotype.Policy) (runResult, error) {

--- a/main_test.go
+++ b/main_test.go
@@ -718,8 +718,9 @@ func TestPrintUsage(t *testing.T) {
 		noCIFail bool
 		groupBy  = types.GroupByNone
 		sevFlag  = newSeverityFlag()
+		ignFlag  = newIgnoreFlag()
 	)
-	registerFlags(pflag.CommandLine, &repo, &nameOnly, &isCount, &isHelp, &noCIFail, &groupBy, sevFlag)
+	registerFlags(pflag.CommandLine, &repo, &nameOnly, &isCount, &isHelp, &noCIFail, &groupBy, sevFlag, ignFlag)
 
 	var out string
 	stdout := captureStdout(t, func() {
@@ -748,6 +749,7 @@ func TestPrintUsage(t *testing.T) {
 		"--help",
 		"--group-by",
 		"--severity",
+		"--ignore",
 		"--no-ci-fail",
 		"ENVIRONMENT",
 		"CI",
@@ -760,20 +762,24 @@ func TestPrintUsage(t *testing.T) {
 		"workflow annotation levels and CI exits",
 		"warning=TODO,HACK",
 		"CONFIGURATION",
-		"Configured custom types are detected alongside the built-in markers.",
-		"Schema: severity:",
+		"Severity overrides and ignored types can be configured",
+		"custom types are detected alongside the built-in markers.",
+		"Schema:",
+		"severity:",
 		"notice|warning|error: [TYPE...]",
+		"ignore:",
+		"- TYPE",
 		"Empty lists are allowed and ignored; a type may not appear under multiple severity levels.",
 		"user config dir/gh-pr-todo/config.yml",
 		".gh-pr-todo.yml",
 		".github/gh-pr-todo.yml",
-		"remote configs",
+		"remote config replaces global config when found",
 		"--group-by",
 		"Group TODO-style comments by: \"file\" or \"type\"",
 		"remote default branch config",
 		"remote PR base branch config",
 		"remote PR head branch config",
-		"CLI --severity flag (highest priority)",
+		"CLI --severity and --ignore flags (highest priority)",
 	}
 	for _, want := range wantContain {
 		if !strings.Contains(out, want) {
@@ -1051,6 +1057,213 @@ func TestSeverityOverrideAffectsWorkflowAnnotation(t *testing.T) {
 		wantLine := "::error file=foo.go,line=2,title=TODO::// TODO: add bar"
 		if !strings.Contains(out, wantLine) {
 			t.Fatalf("runMain output = %q, expected to contain %q", out, wantLine)
+		}
+	})
+}
+
+// Mixed diff with both TODO and NOTE on added lines.
+const mixedDiff = `diff --git a/foo.go b/foo.go
+index 0000000..1111111 100644
+--- a/foo.go
++++ b/foo.go
+@@ -1,1 +1,3 @@
+ package foo
++// TODO: add bar
++// NOTE: important note
+`
+
+func TestIgnoreFlagInvalid(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{name: "empty type", value: "NOTE,"},
+		{name: "type contains equals", value: "NOTE=FIXME"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newIgnoreFlag()
+			err := f.Set(tt.value)
+			if err == nil {
+				t.Fatalf("ignoreFlag.Set(%q) expected error, got nil", tt.value)
+			}
+		})
+	}
+}
+
+func TestIgnoreFlagParsing(t *testing.T) {
+	t.Run("single type", func(t *testing.T) {
+		f := newIgnoreFlag()
+		if err := f.Set("NOTE"); err != nil {
+			t.Fatalf("Set(NOTE) unexpected error: %v", err)
+		}
+		if len(f.types) != 1 || f.types[0] != "NOTE" {
+			t.Fatalf("types = %v, want [NOTE]", f.types)
+		}
+	})
+
+	t.Run("multiple types", func(t *testing.T) {
+		f := newIgnoreFlag()
+		if err := f.Set("NOTE,HACK"); err != nil {
+			t.Fatalf("Set(NOTE,HACK) unexpected error: %v", err)
+		}
+		want := []string{"NOTE", "HACK"}
+		if len(f.types) != 2 || f.types[0] != "NOTE" || f.types[1] != "HACK" {
+			t.Fatalf("types = %v, want %v", f.types, want)
+		}
+	})
+
+	t.Run("repeated flags accumulate", func(t *testing.T) {
+		f := newIgnoreFlag()
+		if err := f.Set("NOTE"); err != nil {
+			t.Fatalf("Set(NOTE) unexpected error: %v", err)
+		}
+		if err := f.Set("HACK"); err != nil {
+			t.Fatalf("Set(HACK) unexpected error: %v", err)
+		}
+		want := []string{"NOTE", "HACK"}
+		if len(f.types) != 2 || f.types[0] != "NOTE" || f.types[1] != "HACK" {
+			t.Fatalf("types = %v, want %v", f.types, want)
+		}
+	})
+
+	t.Run("case normalization", func(t *testing.T) {
+		f := newIgnoreFlag()
+		if err := f.Set("note"); err != nil {
+			t.Fatalf("Set(note) unexpected error: %v", err)
+		}
+		if len(f.types) != 1 || f.types[0] != "NOTE" {
+			t.Fatalf("types = %v, want [NOTE]", f.types)
+		}
+	})
+
+	t.Run("whitespace trimming", func(t *testing.T) {
+		f := newIgnoreFlag()
+		if err := f.Set("  NOTE  ,  HACK  "); err != nil {
+			t.Fatalf("Set with whitespace unexpected error: %v", err)
+		}
+		want := []string{"NOTE", "HACK"}
+		if len(f.types) != 2 || f.types[0] != "NOTE" || f.types[1] != "HACK" {
+			t.Fatalf("types = %v, want %v", f.types, want)
+		}
+	})
+}
+
+func TestIgnoredTypesExcludeFromOutput(t *testing.T) {
+	mixedFetcher := &stubFetcher{
+		diff: mixedDiff,
+		files: map[string][]byte{
+			"foo.go": []byte("package foo\n// TODO: add bar\n// NOTE: important note\n"),
+		},
+	}
+
+	ignoreNOTE := todotype.DefaultPolicy().WithIgnoredTypes([]string{"NOTE"})
+
+	t.Run("default output excludes ignored NOTE", func(t *testing.T) {
+		var result runResult
+		var err error
+		out, _, _ := captureAll(t, func() {
+			result, err = runMain(mixedFetcher, "o/r", "1", types.GroupByNone, false, ignoreNOTE)
+		})
+		if err != nil {
+			t.Fatalf("runMain() unexpected error: %v", err)
+		}
+		if strings.Contains(out, "NOTE") {
+			t.Fatalf("output should not contain NOTE when ignored: %q", out)
+		}
+		if !strings.Contains(out, "TODO: add bar") {
+			t.Fatalf("output should contain TODO: %q", out)
+		}
+		if result.totalCount != 1 {
+			t.Fatalf("totalCount = %d, want 1 (only TODO)", result.totalCount)
+		}
+	})
+
+	t.Run("--count excludes ignored NOTE", func(t *testing.T) {
+		var result runResult
+		var err error
+		out, _, _ := captureAll(t, func() {
+			result, err = runCount(mixedFetcher, "o/r", "1", ignoreNOTE)
+		})
+		if err != nil {
+			t.Fatalf("runCount() unexpected error: %v", err)
+		}
+		if strings.TrimSpace(out) != "1" {
+			t.Fatalf("runCount() output = %q, want %q", out, "1")
+		}
+		if result.totalCount != 1 {
+			t.Fatalf("totalCount = %d, want 1", result.totalCount)
+		}
+	})
+
+	t.Run("--name-only excludes ignored NOTE", func(t *testing.T) {
+		// Both markers are in foo.go, so file should still appear
+		var err error
+		out, _, _ := captureAll(t, func() {
+			_, err = runNameOnly(mixedFetcher, "o/r", "1", ignoreNOTE)
+		})
+		if err != nil {
+			t.Fatalf("runNameOnly() unexpected error: %v", err)
+		}
+		if strings.TrimSpace(out) != "foo.go" {
+			t.Fatalf("runNameOnly() output = %q, want %q", out, "foo.go")
+		}
+	})
+
+	t.Run("group-by type excludes ignored NOTE", func(t *testing.T) {
+		var result runResult
+		var err error
+		out, _, _ := captureAll(t, func() {
+			result, err = runMain(mixedFetcher, "o/r", "1", types.GroupByType, false, ignoreNOTE)
+		})
+		if err != nil {
+			t.Fatalf("runMain() unexpected error: %v", err)
+		}
+		if strings.Contains(out, "[NOTE]") {
+			t.Fatalf("group-by output should not contain [NOTE] section: %q", out)
+		}
+		if !strings.Contains(out, "[TODO]") {
+			t.Fatalf("group-by output should contain [TODO] section: %q", out)
+		}
+		if result.totalCount != 1 {
+			t.Fatalf("totalCount = %d, want 1", result.totalCount)
+		}
+	})
+
+	t.Run("workflow annotations exclude ignored NOTE", func(t *testing.T) {
+		var err error
+		out, _, _ := captureAll(t, func() {
+			_, err = runMain(mixedFetcher, "o/r", "1", types.GroupByNone, true, ignoreNOTE)
+		})
+		if err != nil {
+			t.Fatalf("runMain() unexpected error: %v", err)
+		}
+		if strings.Contains(out, "::notice file=foo.go,line=3,title=NOTE") {
+			t.Fatalf("workflow output should not contain NOTE annotation: %q", out)
+		}
+		if !strings.Contains(out, "::notice file=foo.go,line=2,title=TODO") {
+			t.Fatalf("workflow output should contain TODO annotation: %q", out)
+		}
+	})
+
+	t.Run("CI failure count excludes ignored types", func(t *testing.T) {
+		// NOTE overridden to error would normally fail CI, but if NOTE is ignored it should not
+		policy := todotype.DefaultPolicy().WithSeverity("NOTE", todotype.SeverityError).WithIgnoredTypes([]string{"NOTE"})
+		var result runResult
+		var err error
+		_, _, _ = captureAll(t, func() {
+			result, err = runMain(mixedFetcher, "o/r", "1", types.GroupByNone, false, policy)
+		})
+		if err != nil {
+			t.Fatalf("runMain() unexpected error: %v", err)
+		}
+		if result.ciFailingCount != 0 {
+			t.Fatalf("ciFailingCount = %d, want 0 (NOTE ignored overrides error severity)", result.ciFailingCount)
+		}
+		// TODO should still be detected
+		if result.totalCount != 1 {
+			t.Fatalf("totalCount = %d, want 1 (only TODO)", result.totalCount)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

- Add `ignore` config support and `--ignore` CLI flag for excluding marker types from detection
- Apply whole-file config replacement semantics across local and remote config sources
- Ensure ignored markers are omitted from output, counts, workflow annotations, and CI failure checks
- Update tests and README/help text for ignore behavior and config precedence

Validation:
- `go test -count=1 ./...`

Closes #88