### PR TITLE
feat(init): add non-interactive config targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,21 +85,29 @@ gh pr-todo --ignore NOTE,HACK
 
 ### Initializing Configuration
 
-Use `gh pr-todo init` to create a default configuration file. In a terminal, it uses an interactive selector; when input or output is redirected, it falls back to the plain text prompt:
+Use `gh pr-todo init` to create a default configuration file. Without an explicit location, it prompts in terminals and falls back to a plain text prompt when redirected:
 
 ```bash
 gh pr-todo init
 ```
 
-You will be prompted to choose a location for the config file:
+For non-interactive scripts, pass a location:
+
+```bash
+gh pr-todo init --repo    # Project (.gh-pr-todo.yml)
+gh pr-todo init --global  # user config dir/gh-pr-todo/config.yml
+```
+
+Prompted locations are:
 
 1. `Project (.gh-pr-todo.yml)` — repository-scoped config, created at the root of the current Git repository; shown in the interactive selector only when run inside a Git repository
 2. `Global (user config dir/gh-pr-todo/config.yml)` — global config, shared across all repos (typically `$XDG_CONFIG_HOME/gh-pr-todo/config.yml` on Linux, falling back to `~/.config/gh-pr-todo/config.yml`; actual path depends on your OS)
 
-If the selected config file already exists, `init` refuses to overwrite it unless `--force` is passed. If you choose the repo-root location and `.github/gh-pr-todo.yml` exists, `init` reports it instead because that narrower config takes precedence over the root project config:
+If the selected config file already exists, `init` refuses to overwrite it unless `--force` is passed. `--force` can be combined with `--repo` or `--global`. `--repo` and `--global` are mutually exclusive, and using both returns an error. If you choose the repo-root location and `.github/gh-pr-todo.yml` exists, `init` reports it instead because that narrower config takes precedence over the root project config:
 
 ```bash
 gh pr-todo init --force
+gh pr-todo init --repo --force
 ```
 
 The default configuration matches the runtime severity policy:

--- a/main.go
+++ b/main.go
@@ -41,6 +41,8 @@ func main() {
 		initFS.SetOutput(io.Discard)
 
 		force := initFS.Bool("force", false, "Overwrite existing config file")
+		repoInit := initFS.Bool("repo", false, "Create repo config at <repo>/.gh-pr-todo.yml without prompting")
+		globalInit := initFS.Bool("global", false, "Create global config at user config dir/gh-pr-todo/config.yml without prompting")
 		helpH := initFS.BoolP("help", "h", false, "Display help information")
 
 		if err := initFS.Parse(os.Args[2:]); err != nil {
@@ -59,15 +61,24 @@ func main() {
 			os.Exit(1)
 		}
 
-		cwd, err := os.Getwd()
+		target, err := initTargetFromFlags(*repoInit, *globalInit)
 		if err != nil {
-			fmt.Fprintln(os.Stderr, "Error getting current directory:", err)
+			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
+		}
+
+		cwd := ""
+		if target != initTargetGlobal {
+			cwd, err = os.Getwd()
+			if err != nil {
+				fmt.Fprintln(os.Stderr, "Error getting current directory:", err)
+				os.Exit(1)
+			}
 		}
 
 		userConfigDir, _ := os.UserConfigDir()
 
-		if err := runInit(os.Stdin, os.Stdout, cwd, userConfigDir, *force); err != nil {
+		if err := runInit(os.Stdin, os.Stdout, cwd, userConfigDir, *force, target); err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
@@ -364,7 +375,7 @@ func printUsage() {
 	fmt.Fprintf(color.Output, "%s\n\n", "View TODO-style comments in the PR diff.")
 	fmt.Fprintf(color.Output, "%s\n", output.Bold("USAGE"))
 	fmt.Fprintf(color.Output, "  %s\n", "gh pr-todo [<number> | <url> | <branch>] [flags]")
-	fmt.Fprintf(color.Output, "  %s\n\n", "gh pr-todo init [--force]")
+	fmt.Fprintf(color.Output, "  %s\n\n", "gh pr-todo init [--repo | --global] [--force]")
 	fmt.Fprintf(color.Output, "%s\n", output.Bold("COMMANDS"))
 	fmt.Fprintf(color.Output, "  %s\n", "init    Create a default config file")
 	fmt.Fprintf(color.Output, "  %s\n\n", "        Run 'gh pr-todo init --help' for details.")
@@ -479,11 +490,36 @@ func runNameOnly(fetcher ghclient.PRFetcher, repo, pr string, policy todotype.Po
 	return newRunResult(todos, policy), nil
 }
 
-func runInit(in io.Reader, out io.Writer, cwd, userConfigDir string, force bool) error {
-	repoPath, repoErr := config.RepoRootPath(cwd)
-	globalPath, globalErr := config.GlobalPath(userConfigDir)
+type initTarget int
 
-	path, err := chooseInitPath(in, out, repoPath, repoErr, globalPath, globalErr)
+const (
+	initTargetPrompt initTarget = iota
+	initTargetRepo
+	initTargetGlobal
+)
+
+func initTargetFromFlags(repoFlag, globalFlag bool) (initTarget, error) {
+	switch {
+	case repoFlag && globalFlag:
+		return initTargetPrompt, fmt.Errorf("cannot use --repo and --global together")
+	case repoFlag:
+		return initTargetRepo, nil
+	case globalFlag:
+		return initTargetGlobal, nil
+	default:
+		return initTargetPrompt, nil
+	}
+}
+
+func runInit(in io.Reader, out io.Writer, cwd, userConfigDir string, force bool, target initTarget) error {
+	globalPath, globalErr := config.GlobalPath(userConfigDir)
+	repoPath := ""
+	repoErr := fmt.Errorf("repo config requires a Git repository")
+	if target != initTargetGlobal {
+		repoPath, repoErr = config.RepoRootPath(cwd)
+	}
+
+	path, err := resolveInitPath(in, out, repoPath, repoErr, globalPath, globalErr, target)
 	if err != nil {
 		return err
 	}
@@ -513,6 +549,22 @@ func ensureNoRepoNarrowConfig(cwd, repoPath string) error {
 		return fmt.Errorf("checking %s: %w", narrowPath, err)
 	}
 	return nil
+}
+
+func resolveInitPath(in io.Reader, out io.Writer, repoPath string, repoErr error, globalPath string, globalErr error, target initTarget) (string, error) {
+	switch target {
+	case initTargetRepo:
+		if repoErr != nil {
+			return "", fmt.Errorf("repo config requires a Git repository")
+		}
+		return repoPath, nil
+	case initTargetGlobal:
+		if globalErr != nil || globalPath == "" {
+			return "", fmt.Errorf("user config directory not available")
+		}
+		return globalPath, nil
+	}
+	return chooseInitPath(in, out, repoPath, repoErr, globalPath, globalErr)
 }
 
 func chooseInitPath(in io.Reader, out io.Writer, repoPath string, repoErr error, globalPath string, globalErr error) (string, error) {
@@ -558,6 +610,11 @@ func initPathOptions(repoPath string, repoErr error, globalPath string, globalEr
 	return options
 }
 
+const (
+	initProjectUnavailableLabel = "Project (unavailable: not inside a Git repository)"
+	initGlobalUnavailableLabel  = "Global (unavailable: user config directory not available)"
+)
+
 func initProjectLabel() string {
 	return "Project (.gh-pr-todo.yml)"
 }
@@ -566,25 +623,21 @@ func initGlobalLabel(path string) string {
 	return fmt.Sprintf("Global (%s)", path)
 }
 
-func initProjectUnavailableLabel() string {
-	return "Project (unavailable: not inside a Git repository)"
-}
-
-func initGlobalUnavailableLabel() string {
-	return "Global (unavailable: user config directory not available)"
-}
-
 func chooseInitPathText(in io.Reader, out io.Writer, repoPath string, repoErr error, globalPath string, globalErr error) (string, error) {
+	if repoErr != nil && (globalErr != nil || globalPath == "") {
+		return "", fmt.Errorf("no config file location available")
+	}
+
 	fmt.Fprintln(out, "Choose config file location:")
 	if repoErr == nil {
 		fmt.Fprintf(out, "  1) %s\n", initProjectLabel())
 	} else {
-		fmt.Fprintf(out, "  1) %s\n", initProjectUnavailableLabel())
+		fmt.Fprintf(out, "  1) %s\n", initProjectUnavailableLabel)
 	}
 	if globalErr == nil && globalPath != "" {
 		fmt.Fprintf(out, "  2) %s\n", initGlobalLabel(globalPath))
 	} else {
-		fmt.Fprintf(out, "  2) %s\n", initGlobalUnavailableLabel())
+		fmt.Fprintf(out, "  2) %s\n", initGlobalUnavailableLabel)
 	}
 	fmt.Fprint(out, "Enter selection: ")
 
@@ -630,9 +683,9 @@ func isTerminalFile(v any) bool {
 }
 
 func printInitUsage(fs *pflag.FlagSet) {
-	fmt.Fprintf(color.Output, "%s\n\n", "Create a default config file with interactive prompts.")
+	fmt.Fprintf(color.Output, "%s\n\n", "Create a default config file.")
 	fmt.Fprintf(color.Output, "%s\n", output.Bold("USAGE"))
-	fmt.Fprintf(color.Output, "  %s\n\n", "gh pr-todo init [--force]")
+	fmt.Fprintf(color.Output, "  %s\n\n", "gh pr-todo init [--repo | --global] [--force]")
 	fmt.Fprintf(color.Output, "%s\n", output.Bold("FLAGS"))
 	fs.VisitAll(func(f *pflag.Flag) {
 		if f.Shorthand != "" {
@@ -643,10 +696,10 @@ func printInitUsage(fs *pflag.FlagSet) {
 	})
 	fmt.Fprintln(color.Output)
 	fmt.Fprintf(color.Output, "%s\n", output.Bold("DESCRIPTION"))
-	fmt.Fprintf(color.Output, "  %s\n", "Creates a default configuration file with an interactive terminal selector or a plain text prompt when redirected.")
-	fmt.Fprintf(color.Output, "  %s\n", "Available locations:")
-	fmt.Fprintf(color.Output, "  %s\n", "  - Project (.gh-pr-todo.yml): repository scope; shown interactively only inside a Git repository")
-	fmt.Fprintf(color.Output, "  %s\n", "  - Global (user config dir/gh-pr-todo/config.yml): global scope")
+	fmt.Fprintf(color.Output, "  %s\n", "Creates a default configuration file. Without --repo or --global, init prompts for a location.")
+	fmt.Fprintf(color.Output, "  %s\n", "Locations:")
+	fmt.Fprintf(color.Output, "  %s\n", "  - --repo: Project (.gh-pr-todo.yml), available inside a Git repository")
+	fmt.Fprintf(color.Output, "  %s\n", "  - --global: user config dir/gh-pr-todo/config.yml")
 	fmt.Fprintf(color.Output, "  %s\n", "")
 	fmt.Fprintf(color.Output, "  %s\n", "Use --force to overwrite an existing project or global config file.")
 	fmt.Fprintf(color.Output, "  %s\n", "If you choose repo scope and .github/gh-pr-todo.yml exists, move or remove it first because it takes precedence.")

--- a/main_test.go
+++ b/main_test.go
@@ -740,6 +740,7 @@ func TestPrintUsage(t *testing.T) {
 		"View TODO-style comments in the PR diff.",
 		"USAGE",
 		"gh pr-todo [<number> | <url> | <branch>] [flags]",
+		"gh pr-todo init [--repo | --global] [--force]",
 		"FLAGS",
 		"--repo",
 		"Display only names of the files containing TODO-style comments",
@@ -784,6 +785,38 @@ func TestPrintUsage(t *testing.T) {
 	for _, want := range wantContain {
 		if !strings.Contains(out, want) {
 			t.Fatalf("printUsage() output = %q, expected to contain %q", out, want)
+		}
+	}
+}
+
+func TestPrintInitUsage(t *testing.T) {
+	initFS := pflag.NewFlagSet("gh pr-todo init", pflag.ContinueOnError)
+	initFS.Bool("force", false, "Overwrite existing config file")
+	initFS.Bool("repo", false, "Create repo config at <repo>/.gh-pr-todo.yml without prompting")
+	initFS.Bool("global", false, "Create global config at user config dir/gh-pr-todo/config.yml without prompting")
+	initFS.BoolP("help", "h", false, "Display help information")
+
+	var out string
+	stdout := captureStdout(t, func() {
+		out = captureColorOutput(t, func() {
+			printInitUsage(initFS)
+		})
+	})
+
+	if stdout != "" {
+		t.Fatalf("printInitUsage() leaked to os.Stdout: %q", stdout)
+	}
+	wantContain := []string{
+		"gh pr-todo init [--repo | --global] [--force]",
+		"Create repo config at <repo>/.gh-pr-todo.yml without prompting",
+		"Create global config at user config dir/gh-pr-todo/config.yml without prompting",
+		"--repo: Project (.gh-pr-todo.yml)",
+		"--global: user config dir/gh-pr-todo/config.yml",
+		"Use --force to overwrite",
+	}
+	for _, want := range wantContain {
+		if !strings.Contains(out, want) {
+			t.Fatalf("printInitUsage() output = %q, expected to contain %q", out, want)
 		}
 	}
 }
@@ -1322,18 +1355,38 @@ func TestChooseInitPathTextLabels(t *testing.T) {
 		}
 	})
 
-	t.Run("unavailable locations include scoped messages", func(t *testing.T) {
+	t.Run("unavailable repo location includes scoped message", func(t *testing.T) {
 		var buf bytes.Buffer
-		_, err := chooseInitPathText(strings.NewReader(""), &buf, repoPath, errors.New("not inside a Git repository"), globalPath, errors.New("user config directory is empty"))
-		if err == nil {
-			t.Fatal("chooseInitPathText() expected input error")
+		_, err := chooseInitPathText(strings.NewReader("2\n"), &buf, repoPath, errors.New("not inside a Git repository"), globalPath, nil)
+		if err != nil {
+			t.Fatalf("chooseInitPathText() unexpected error: %v", err)
 		}
 		output := buf.String()
 		if !strings.Contains(output, "1) Project (unavailable: not inside a Git repository)") {
 			t.Fatalf("output = %q, expected unavailable project label", output)
 		}
+	})
+
+	t.Run("unavailable global location includes scoped message", func(t *testing.T) {
+		var buf bytes.Buffer
+		_, err := chooseInitPathText(strings.NewReader("1\n"), &buf, repoPath, nil, globalPath, errors.New("user config directory is empty"))
+		if err != nil {
+			t.Fatalf("chooseInitPathText() unexpected error: %v", err)
+		}
+		output := buf.String()
 		if !strings.Contains(output, "2) Global (unavailable: user config directory not available)") {
 			t.Fatalf("output = %q, expected unavailable global label", output)
+		}
+	})
+
+	t.Run("no available locations returns before prompting", func(t *testing.T) {
+		var buf bytes.Buffer
+		_, err := chooseInitPathText(strings.NewReader(""), &buf, repoPath, errors.New("not inside a Git repository"), "", errors.New("user config directory is empty"))
+		if err == nil || !strings.Contains(err.Error(), "no config file location available") {
+			t.Fatalf("chooseInitPathText() error = %v, want no location error", err)
+		}
+		if strings.Contains(buf.String(), "Enter selection") {
+			t.Fatalf("output = %q, expected no prompt", buf.String())
 		}
 	})
 }
@@ -1347,6 +1400,39 @@ func TestShouldUseInteractivePrompt(t *testing.T) {
 	}
 }
 
+func TestInitTargetFromFlags(t *testing.T) {
+	tests := []struct {
+		name       string
+		repoFlag   bool
+		globalFlag bool
+		want       initTarget
+		wantErr    string
+	}{
+		{name: "prompt", want: initTargetPrompt},
+		{name: "repo", repoFlag: true, want: initTargetRepo},
+		{name: "global", globalFlag: true, want: initTargetGlobal},
+		{name: "conflict", repoFlag: true, globalFlag: true, wantErr: "cannot use --repo and --global together"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := initTargetFromFlags(tt.repoFlag, tt.globalFlag)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("initTargetFromFlags() error = %v, want %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("initTargetFromFlags() unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("initTargetFromFlags() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestRunInit(t *testing.T) {
 	t.Run("selection 1 creates repo config", func(t *testing.T) {
 		repoRoot := t.TempDir()
@@ -1356,7 +1442,7 @@ func TestRunInit(t *testing.T) {
 
 		var buf bytes.Buffer
 		in := strings.NewReader("1\n")
-		err := runInit(in, &buf, repoRoot, t.TempDir(), false)
+		err := runInit(in, &buf, repoRoot, t.TempDir(), false, initTargetPrompt)
 		if err != nil {
 			t.Fatalf("runInit() unexpected error: %v", err)
 		}
@@ -1374,7 +1460,7 @@ func TestRunInit(t *testing.T) {
 		userConfigDir := t.TempDir()
 		var buf bytes.Buffer
 		in := strings.NewReader("2\n")
-		err := runInit(in, &buf, t.TempDir(), userConfigDir, false)
+		err := runInit(in, &buf, t.TempDir(), userConfigDir, false, initTargetPrompt)
 		if err != nil {
 			t.Fatalf("runInit() unexpected error: %v", err)
 		}
@@ -1388,11 +1474,71 @@ func TestRunInit(t *testing.T) {
 		}
 	})
 
+	t.Run("repo target creates repo config without prompt", func(t *testing.T) {
+		repoRoot := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(repoRoot, ".git"), 0755); err != nil {
+			t.Fatalf("MkdirAll() error: %v", err)
+		}
+
+		var buf bytes.Buffer
+		err := runInit(strings.NewReader(""), &buf, repoRoot, t.TempDir(), false, initTargetRepo)
+		if err != nil {
+			t.Fatalf("runInit() unexpected error: %v", err)
+		}
+
+		wantPath := filepath.Join(repoRoot, ".gh-pr-todo.yml")
+		if _, err := os.Stat(wantPath); err != nil {
+			t.Fatalf("expected file at %s: %v", wantPath, err)
+		}
+		if strings.Contains(buf.String(), "Enter selection") {
+			t.Fatalf("output = %q, expected no prompt", buf.String())
+		}
+	})
+
+	t.Run("global target creates global config without prompt", func(t *testing.T) {
+		userConfigDir := t.TempDir()
+		var buf bytes.Buffer
+		err := runInit(strings.NewReader(""), &buf, filepath.Join(t.TempDir(), "missing"), userConfigDir, false, initTargetGlobal)
+		if err != nil {
+			t.Fatalf("runInit() unexpected error: %v", err)
+		}
+
+		wantPath := filepath.Join(userConfigDir, "gh-pr-todo", "config.yml")
+		if _, err := os.Stat(wantPath); err != nil {
+			t.Fatalf("expected file at %s: %v", wantPath, err)
+		}
+		if strings.Contains(buf.String(), "Enter selection") {
+			t.Fatalf("output = %q, expected no prompt", buf.String())
+		}
+	})
+
+	t.Run("repo target outside repo returns error without prompt", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := runInit(strings.NewReader(""), &buf, t.TempDir(), t.TempDir(), false, initTargetRepo)
+		if err == nil || !strings.Contains(err.Error(), "Git repository") {
+			t.Fatalf("runInit() error = %v, want Git repository error", err)
+		}
+		if strings.Contains(buf.String(), "Enter selection") {
+			t.Fatalf("output = %q, expected no prompt", buf.String())
+		}
+	})
+
+	t.Run("global target without user config dir returns error without prompt", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := runInit(strings.NewReader(""), &buf, filepath.Join(t.TempDir(), "missing"), "", false, initTargetGlobal)
+		if err == nil || !strings.Contains(err.Error(), "user config directory not available") {
+			t.Fatalf("runInit() error = %v, want user config dir error", err)
+		}
+		if strings.Contains(buf.String(), "Enter selection") {
+			t.Fatalf("output = %q, expected no prompt", buf.String())
+		}
+	})
+
 	t.Run("selection without trailing newline is accepted", func(t *testing.T) {
 		userConfigDir := t.TempDir()
 		var buf bytes.Buffer
 		in := strings.NewReader("2")
-		err := runInit(in, &buf, t.TempDir(), userConfigDir, false)
+		err := runInit(in, &buf, t.TempDir(), userConfigDir, false, initTargetPrompt)
 		if err != nil {
 			t.Fatalf("runInit() unexpected error: %v", err)
 		}
@@ -1416,7 +1562,7 @@ func TestRunInit(t *testing.T) {
 
 		var buf bytes.Buffer
 		in := strings.NewReader("1\n")
-		err := runInit(in, &buf, repoRoot, t.TempDir(), false)
+		err := runInit(in, &buf, repoRoot, t.TempDir(), false, initTargetPrompt)
 		if err == nil {
 			t.Fatal("runInit() expected error for existing file without force")
 		}
@@ -1449,7 +1595,7 @@ func TestRunInit(t *testing.T) {
 
 		var buf bytes.Buffer
 		in := strings.NewReader("1\n")
-		err := runInit(in, &buf, repoRoot, t.TempDir(), false)
+		err := runInit(in, &buf, repoRoot, t.TempDir(), false, initTargetPrompt)
 		if err == nil {
 			t.Fatal("runInit() expected error for existing narrow repo config")
 		}
@@ -1475,7 +1621,7 @@ func TestRunInit(t *testing.T) {
 
 		var buf bytes.Buffer
 		in := strings.NewReader("1\n")
-		err := runInit(in, &buf, repoRoot, t.TempDir(), true)
+		err := runInit(in, &buf, repoRoot, t.TempDir(), true, initTargetPrompt)
 		if err != nil {
 			t.Fatalf("runInit() with force unexpected error: %v", err)
 		}
@@ -1496,7 +1642,7 @@ func TestRunInit(t *testing.T) {
 	t.Run("invalid selection returns error", func(t *testing.T) {
 		var buf bytes.Buffer
 		in := strings.NewReader("3\n")
-		err := runInit(in, &buf, t.TempDir(), t.TempDir(), false)
+		err := runInit(in, &buf, t.TempDir(), t.TempDir(), false, initTargetPrompt)
 		if err == nil {
 			t.Fatal("runInit() expected error for invalid selection")
 		}
@@ -1508,7 +1654,7 @@ func TestRunInit(t *testing.T) {
 	t.Run("EOF returns error", func(t *testing.T) {
 		var buf bytes.Buffer
 		in := strings.NewReader("") // EOF on first read
-		err := runInit(in, &buf, t.TempDir(), t.TempDir(), false)
+		err := runInit(in, &buf, t.TempDir(), t.TempDir(), false, initTargetPrompt)
 		if err == nil {
 			t.Fatal("runInit() expected error for EOF")
 		}
@@ -1517,7 +1663,7 @@ func TestRunInit(t *testing.T) {
 	t.Run("empty input returns error", func(t *testing.T) {
 		var buf bytes.Buffer
 		in := strings.NewReader("\n") // Just newline = empty after trim
-		err := runInit(in, &buf, t.TempDir(), t.TempDir(), false)
+		err := runInit(in, &buf, t.TempDir(), t.TempDir(), false, initTargetPrompt)
 		if err == nil {
 			t.Fatal("runInit() expected error for empty input")
 		}
@@ -1530,7 +1676,7 @@ func TestRunInit(t *testing.T) {
 		var buf bytes.Buffer
 		in := strings.NewReader("1\n")
 		cwd := t.TempDir() // No .git directory
-		err := runInit(in, &buf, cwd, t.TempDir(), false)
+		err := runInit(in, &buf, cwd, t.TempDir(), false, initTargetPrompt)
 		if err == nil {
 			t.Fatal("runInit() expected error for local outside repo")
 		}


### PR DESCRIPTION
## Summary

- Add non-interactive `gh pr-todo init --repo` and `--global` targets
- Keep `--repo` aligned with the existing Project target (`.gh-pr-todo.yml`)
- Update init help, top-level usage, README docs, and tests for target selection/conflict handling

Closes #89


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--repo` and `--global` flags to the `init` command to explicitly specify where configuration should be initialized.

* **Documentation**
  * Expanded "Initializing Configuration" documentation with detailed instructions covering default behavior, flag examples, config locations, `--force` overwrite behavior, and precedence when configuration exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->