### PR TITLE
docs: align README and help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,12 @@ A GitHub CLI extension that extracts TODO-style comments from pull request diffs
 
 ## Features
 
-- **Syntax-Aware Detection**: Uses Tree-sitter for accurate TODO-style comment detection in supported languages, with regex fallback for others
-- **Beautiful Output**: Colorized terminal output with loading indicators
-- **Multiple Formats**: Supports various comment styles (`//`, `#`, `<!--`, `;`, `/*`)
-- **Fast**: Efficient diff parsing with GitHub CLI integration
-- **PR-Focused**: Only shows comments from your current changes
+- **PR-Focused Detection**: Extracts TODO-style comments only from pull request diff additions
+- **Syntax-Aware Parsing**: Uses Tree-sitter for accurate comment detection in supported languages, with regex fallback for others
+- **Configurable Marker Policy**: Customize marker types, severities, and ignored types with CLI flags or YAML config
+- **Config Initialization**: Create project or global config files with `gh pr-todo init`
+- **CI and GitHub Actions Support**: Emit workflow annotations and fail CI only for marker types configured as `error`
+- **Flexible Output**: Colorized output with grouping, file-name-only, and count-only modes
 
 ## Installation
 
@@ -76,7 +77,7 @@ gh pr-todo --ignore NOTE,HACK
 - `[<number> | <url> | <branch>]`: Specify a PR by number, URL, or branch name
 - `-R, --repo [HOST/]OWNER/REPO`: Select another repository using the [HOST/]OWNER/REPO format (requires a PR number, URL, or branch argument)
 - `--group-by`: Group TODO-style comments by `file` or `type`
-- `--name-only`: Display only names of the files containing TODO-style comments
+- `--name-only`: Display only names of the files containing TODO-style comments. If both `--name-only` and `--count` are specified, `--name-only` takes precedence
 - `-c, --count`: Display only the number of TODO-style comments
 - `--severity LEVEL=TYPE[,TYPE...]`: Override severity for one or more TODO types; repeatable, whitespace-tolerant, and last assignment wins for duplicate types
 - `--ignore TYPE[,TYPE...]`: Ignore specified marker types; repeatable, case-insensitive, whitespace-tolerant. Ignored types are not detected or reported in any mode, including annotations and CI failure counts

--- a/main.go
+++ b/main.go
@@ -23,8 +23,8 @@ import (
 )
 
 func registerFlags(fs *pflag.FlagSet, repo *string, nameOnly, isCount, isHelp, noCIFail *bool, groupBy *types.GroupBy, sevFlag *severityFlag, ignoreFlag *ignoreFlag) {
-	fs.StringVarP(repo, "repo", "R", "", "Select another repository using the [HOST/]OWNER/REPO format")
-	fs.BoolVar(nameOnly, "name-only", false, "Display only names of the files containing TODO-style comments")
+	fs.StringVarP(repo, "repo", "R", "", "Select another repository using the [HOST/]OWNER/REPO format; requires a PR number, URL, or branch argument")
+	fs.BoolVar(nameOnly, "name-only", false, "Display only names of the files containing TODO-style comments; takes precedence over --count")
 	fs.BoolVarP(isCount, "count", "c", false, "Display only the number of TODO-style comments")
 	fs.BoolVarP(isHelp, "help", "h", false, "Display help information")
 	fs.BoolVar(noCIFail, "no-ci-fail", false, "Disable non-zero exit when error-level TODOs are found in CI")
@@ -406,6 +406,8 @@ func printUsage() {
 	fmt.Fprintf(color.Output, "  %s\n", "GITHUB_ACTIONS   When truthy, emits GitHub Actions workflow annotations.")
 	fmt.Fprintf(color.Output, "  %s\n", "                 Implies CI=true; --no-ci-fail suppresses error-level exits.")
 	fmt.Fprintf(color.Output, "  %s\n\n", "                 Only emitted in the default mode; --count and --name-only stay machine-readable.")
+	fmt.Fprintf(color.Output, "%s\n", output.Bold("OUTPUT MODES"))
+	fmt.Fprintf(color.Output, "  %s\n\n", "If --name-only and --count are both specified, --name-only takes precedence.")
 	fmt.Fprintf(color.Output, "%s\n", output.Bold("SEVERITY OVERRIDES"))
 	fmt.Fprintf(color.Output, "  %s\n", "Use --severity LEVEL=TYPE[,TYPE...] to override severities.")
 	fmt.Fprintf(color.Output, "  %s\n", "Affects workflow annotation levels and CI exits for error-level types.")
@@ -436,7 +438,14 @@ func printUsage() {
 	fmt.Fprintf(color.Output, "  %s\n", "  3. remote default branch config")
 	fmt.Fprintf(color.Output, "  %s\n", "  4. global config (fallback only when no remote config exists)")
 	fmt.Fprintf(color.Output, "  %s\n", "  5. CLI --severity and --ignore flags (highest priority)")
-	fmt.Fprintf(color.Output, "  %s\n\n", "Example config:  # .gh-pr-todo.yml\nseverity:\n  warning:\n    - TODO\n  error:\n    - FIXME\nignore:\n  - NOTE")
+	fmt.Fprintf(color.Output, "  %s\n", "Example config:  # .gh-pr-todo.yml")
+	fmt.Fprintf(color.Output, "  %s\n", "severity:")
+	fmt.Fprintf(color.Output, "  %s\n", "  warning:")
+	fmt.Fprintf(color.Output, "  %s\n", "    - TODO")
+	fmt.Fprintf(color.Output, "  %s\n", "  error:")
+	fmt.Fprintf(color.Output, "  %s\n", "    - FIXME")
+	fmt.Fprintf(color.Output, "  %s\n", "ignore:")
+	fmt.Fprintf(color.Output, "  %s\n\n", "  - NOTE")
 }
 
 func runMain(fetcher ghclient.PRFetcher, repo, pr string, groupBy types.GroupBy, gha bool, policy todotype.Policy) (runResult, error) {

--- a/main_test.go
+++ b/main_test.go
@@ -743,7 +743,9 @@ func TestPrintUsage(t *testing.T) {
 		"gh pr-todo init [--repo | --global] [--force]",
 		"FLAGS",
 		"--repo",
+		"requires a PR number, URL, or branch argument",
 		"Display only names of the files containing TODO-style comments",
+		"takes precedence over --count",
 		"--name-only",
 		"Display only the number of TODO-style comments",
 		"--count",
@@ -758,6 +760,8 @@ func TestPrintUsage(t *testing.T) {
 		"error-level TODO is found.",
 		"By default, no built-in",
 		"keyword maps to error-level",
+		"OUTPUT MODES",
+		"If --name-only and --count are both specified, --name-only takes precedence.",
 		"SEVERITY OVERRIDES",
 		"LEVEL=TYPE[,TYPE...]",
 		"workflow annotation levels and CI exits",
@@ -781,6 +785,7 @@ func TestPrintUsage(t *testing.T) {
 		"remote PR base branch config",
 		"remote PR head branch config",
 		"CLI --severity and --ignore flags (highest priority)",
+		"Example config:  # .gh-pr-todo.yml",
 	}
 	for _, want := range wantContain {
 		if !strings.Contains(out, want) {


### PR DESCRIPTION
## Summary

- Refresh README Features to highlight the implemented config, custom marker, init, and GitHub Actions capabilities
- Align `--help` wording with runtime behavior for `--repo` and output-mode precedence
- Document that `--name-only` takes precedence over `--count` and cover the new help text in tests

Closes #90

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved CLI help text with clearer `--repo` flag format requirements (`[HOST/]OWNER/REPO`).
  * Added "OUTPUT MODES" section clarifying `--name-only` takes precedence over `--count`.
  * Updated feature descriptions in README highlighting PR detection, parsing methods, and output flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->