### PR TITLE
refactor(github): deduplicate raw file content fetching

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -100,9 +100,7 @@ func (c *Client) FetchRemoteConfigRefs(repo, pr string) (config.RemoteConfigRefs
 	return refs, nil
 }
 
-// FetchFileAtRef fetches a file from the repository at a specific ref.
-// Returns (nil, false, nil) when the file is not found (404).
-func (c *Client) FetchFileAtRef(repo, path, ref string) ([]byte, bool, error) {
+func (c *Client) fetchRawFileContent(repo, path, ref string) ([]byte, string, error) {
 	host, repoPath := splitHostRepo(repo)
 	segments := strings.Split(path, "/")
 	for i, s := range segments {
@@ -114,13 +112,20 @@ func (c *Client) FetchFileAtRef(repo, path, ref string) ([]byte, bool, error) {
 		args = append(args, "--hostname", host)
 	}
 	out, stdErr, err := ghExec(args...)
+	return out.Bytes(), stdErr.String(), err
+}
+
+// FetchFileAtRef fetches a file from the repository at a specific ref.
+// Returns (nil, false, nil) when the file is not found (404).
+func (c *Client) FetchFileAtRef(repo, path, ref string) ([]byte, bool, error) {
+	data, stderr, err := c.fetchRawFileContent(repo, path, ref)
 	if err != nil {
-		if strings.Contains(stdErr.String(), "Not Found") || strings.Contains(stdErr.String(), "404") {
+		if strings.Contains(stderr, "Not Found") || strings.Contains(stderr, "404") {
 			return nil, false, nil
 		}
 		return nil, false, fmt.Errorf("fetching %s from %s at %s: %w", path, repo, ref, err)
 	}
-	return out.Bytes(), true, nil
+	return data, true, nil
 }
 
 func splitHostRepo(repo string) (string, string) {
@@ -198,21 +203,12 @@ func (c *Client) FetchChangedFileContents(repo, pr, diffOutput string) (map[stri
 	files := make(map[string][]byte, len(paths))
 	var failedPaths []string
 	for _, p := range paths {
-		segments := strings.Split(p, "/")
-		for i, s := range segments {
-			segments[i] = url.PathEscape(s)
-		}
-		apiPath := fmt.Sprintf("repos/%s/contents/%s?ref=%s", nwo, strings.Join(segments, "/"), url.QueryEscape(sha))
-		args := []string{"api", apiPath, "-H", "Accept: application/vnd.github.raw+json"}
-		if host != "" {
-			args = append(args, "--hostname", host)
-		}
-		out, _, err := ghExec(args...)
+		data, _, err := c.fetchRawFileContent(withHost(host, nwo), p, sha)
 		if err != nil {
 			failedPaths = append(failedPaths, p)
 			continue
 		}
-		files[p] = out.Bytes()
+		files[p] = data
 	}
 	if len(failedPaths) > 0 {
 		return files, fmt.Errorf("failed to fetch %d changed file(s)", len(failedPaths))

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -410,7 +410,7 @@ func TestFetchChangedFileContents(t *testing.T) {
 		}
 	})
 
-	t.Run("host-qualified repo passes hostname when fetching changed file contents", func(t *testing.T) {
+	t.Run("escapes changed file path and ref when fetching raw contents", func(t *testing.T) {
 		metaJSON := `{"headRefOid":"feature/sha","headRepository":{"nameWithOwner":"o/r"}}`
 		var calls [][]string
 		withGhExec(t, func(args ...string) (bytes.Buffer, bytes.Buffer, error) {
@@ -422,14 +422,25 @@ func TestFetchChangedFileContents(t *testing.T) {
 			return *bytes.NewBufferString("file contents"), bytes.Buffer{}, nil
 		})
 
-		_, err := NewClient().FetchChangedFileContents("github.example.com/o/r", "1", sampleDiff)
+		diffWithEscapedPath := `diff --git a/.github/gh pr-todo.yml b/.github/gh pr-todo.yml
+index 0000000..1111111 100644
+--- a/.github/gh pr-todo.yml
++++ b/.github/gh pr-todo.yml
+@@ -1,1 +1,2 @@
+ severity:
++  TODO: error
+`
+		got, err := NewClient().FetchChangedFileContents("github.example.com/o/r", "1", diffWithEscapedPath)
 		if err != nil {
 			t.Fatalf("FetchChangedFileContents() unexpected error: %v", err)
+		}
+		if string(got[".github/gh pr-todo.yml"]) != "file contents" {
+			t.Fatalf("got %v", got)
 		}
 		if len(calls) != 2 {
 			t.Fatalf("expected 2 calls, got %d: %v", len(calls), calls)
 		}
-		want := []string{"api", "repos/o/r/contents/foo.go?ref=feature%2Fsha", "-H", "Accept: application/vnd.github.raw+json", "--hostname", "github.example.com"}
+		want := []string{"api", "repos/o/r/contents/.github/gh%20pr-todo.yml?ref=feature%2Fsha", "-H", "Accept: application/vnd.github.raw+json", "--hostname", "github.example.com"}
 		if !reflect.DeepEqual(calls[1], want) {
 			t.Fatalf("second call args = %v, expected %v", calls[1], want)
 		}


### PR DESCRIPTION
## Summary
- extract a shared helper for GitHub raw file content requests at a ref
- reuse the helper in config and changed-file content fetching without changing 404/fallback behavior
- add coverage for changed-file path escaping together with enterprise hostname handling

Closes #97


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of file paths containing special characters and spaces in file content retrieval operations to ensure proper URL encoding of path segments.

* **Refactor**
  * Consolidated file content retrieval logic across multiple operations to reduce code duplication and improve internal maintainability of file handling processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->