### PR TITLE
refactor(todotype): centralize severity and marker type parsing

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,26 +41,16 @@ func Parse(data []byte, source string) (Config, error) {
 		severities := make(map[string]todotype.Severity)
 		for levelStr, typeNames := range f.Severity {
 			normalizedLevel := strings.ToLower(strings.TrimSpace(levelStr))
-
-			var sev todotype.Severity
-			switch normalizedLevel {
-			case "notice":
-				sev = todotype.SeverityNotice
-			case "warning":
-				sev = todotype.SeverityWarning
-			case "error":
-				sev = todotype.SeverityError
-			default:
+			sev, ok := todotype.ParseSeverity(levelStr)
+			if !ok {
 				return Config{}, fmt.Errorf("%s: invalid severity key %q: allowed values are notice, warning, error",
 					source, levelStr)
 			}
 
-			for _, typeName := range typeNames {
-				normalizedType := strings.TrimSpace(typeName)
+			for _, normalizedType := range todotype.NormalizeConfiguredTypes(typeNames) {
 				if normalizedType == "" {
 					return Config{}, fmt.Errorf("%s: type name is empty in severity %q", source, normalizedLevel)
 				}
-				normalizedType = strings.ToUpper(normalizedType)
 
 				if existingSev, exists := severities[normalizedType]; exists && existingSev != sev {
 					return Config{}, fmt.Errorf("%s: type %q appears under multiple severity levels (%s and %s)",
@@ -75,8 +65,7 @@ func Parse(data []byte, source string) (Config, error) {
 	// Parse ignore list
 	if len(f.Ignore) > 0 {
 		ignored := make(map[string]bool)
-		for _, t := range f.Ignore {
-			normalized := strings.ToUpper(strings.TrimSpace(t))
+		for _, normalized := range todotype.NormalizeConfiguredTypes(f.Ignore) {
 			if normalized == "" {
 				return Config{}, fmt.Errorf("%s: type name is empty in ignore list", source)
 			}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -210,6 +210,20 @@ func TestParse(t *testing.T) {
 		}
 	})
 
+	t.Run("ignore list duplicates are case-insensitive no-op", func(t *testing.T) {
+		data := []byte("ignore:\n  - note\n  - NOTE\n")
+		cfg, err := Parse(data, "test")
+		if err != nil {
+			t.Fatalf("Parse() unexpected error: %v", err)
+		}
+		if !cfg.Ignored["NOTE"] {
+			t.Fatalf("expected NOTE ignored, got %v", cfg.Ignored)
+		}
+		if len(cfg.Ignored) != 1 {
+			t.Fatalf("len(Ignored) = %d, want 1", len(cfg.Ignored))
+		}
+	})
+
 	t.Run("empty ignore list results in nil map", func(t *testing.T) {
 		data := []byte("ignore: []")
 		cfg, err := Parse(data, "test")

--- a/internal/todotype/configured.go
+++ b/internal/todotype/configured.go
@@ -1,0 +1,39 @@
+package todotype
+
+import "strings"
+
+// ParseSeverity parses a configured severity level.
+//
+// The input is trimmed and matched case-insensitively so CLI flags and YAML
+// config files share the same normalization behavior.
+func ParseSeverity(value string) (Severity, bool) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "notice":
+		return SeverityNotice, true
+	case "warning":
+		return SeverityWarning, true
+	case "error":
+		return SeverityError, true
+	default:
+		return "", false
+	}
+}
+
+// NormalizeConfiguredType normalizes a configured TODO marker type.
+//
+// The input is trimmed and uppercased. Validation such as rejecting empty
+// strings or CLI-specific separator characters is left to the caller so each
+// input path can preserve its existing error behavior.
+func NormalizeConfiguredType(value string) string {
+	return strings.ToUpper(strings.TrimSpace(value))
+}
+
+// NormalizeConfiguredTypes normalizes a configured TODO marker type list while
+// preserving order and duplicates for caller-specific handling.
+func NormalizeConfiguredTypes(values []string) []string {
+	normalized := make([]string, len(values))
+	for i, value := range values {
+		normalized[i] = NormalizeConfiguredType(value)
+	}
+	return normalized
+}

--- a/internal/todotype/todotype_test.go
+++ b/internal/todotype/todotype_test.go
@@ -324,6 +324,40 @@ func TestSeverityErrorConstant(t *testing.T) {
 	}
 }
 
+func TestParseSeverity(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  Severity
+		ok    bool
+	}{
+		{name: "notice", input: "notice", want: SeverityNotice, ok: true},
+		{name: "warning with spaces", input: "  warning  ", want: SeverityWarning, ok: true},
+		{name: "error mixed case", input: "Error", want: SeverityError, ok: true},
+		{name: "invalid", input: "critical", ok: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := ParseSeverity(tt.input)
+			if ok != tt.ok {
+				t.Fatalf("ParseSeverity(%q) ok = %v, want %v", tt.input, ok, tt.ok)
+			}
+			if got != tt.want {
+				t.Fatalf("ParseSeverity(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeConfiguredTypes(t *testing.T) {
+	got := NormalizeConfiguredTypes([]string{" todo ", "FixMe", "a=b", "  "})
+	want := []string{"TODO", "FIXME", "A=B", ""}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("NormalizeConfiguredTypes() = %v, want %v", got, want)
+	}
+}
+
 func TestDefaultTypes(t *testing.T) {
 	got := DefaultTypes()
 	want := []string{"BUG", "FIXME", "HACK", "NOTE", "TODO", "XXX"}

--- a/main.go
+++ b/main.go
@@ -256,29 +256,24 @@ func (s *severityFlag) Set(val string) error {
 		return fmt.Errorf("invalid --severity %q: type list is empty", val)
 	}
 
-	var severity todotype.Severity
-	switch strings.ToLower(levelStr) {
-	case "notice":
-		severity = todotype.SeverityNotice
-	case "warning":
-		severity = todotype.SeverityWarning
-	case "error":
-		severity = todotype.SeverityError
-	default:
+	severity, ok := todotype.ParseSeverity(levelStr)
+	if !ok {
 		return fmt.Errorf("invalid severity level %q in --severity %q: allowed values are notice, warning, error", levelStr, val)
 	}
 
+	rawTypes := strings.Split(typesStr, ",")
+	normalizedTypes := todotype.NormalizeConfiguredTypes(rawTypes)
 	pending := make(map[string]todotype.Severity)
-	for _, typ := range strings.Split(typesStr, ",") {
-		t := strings.TrimSpace(typ)
-		if t == "" {
+	for i, normalizedType := range normalizedTypes {
+		rawType := strings.TrimSpace(rawTypes[i])
+		if normalizedType == "" {
 			return fmt.Errorf("invalid --severity %q: type name is empty", val)
 		}
-		if strings.ContainsRune(t, '=') {
-			return fmt.Errorf("invalid --severity %q: type name %q must not contain '='", val, t)
+		if strings.ContainsRune(rawType, '=') {
+			return fmt.Errorf("invalid --severity %q: type name %q must not contain '='", val, rawType)
 		}
 		// Normalize type to uppercase for last-wins semantics across flags.
-		pending[strings.ToUpper(t)] = severity
+		pending[normalizedType] = severity
 	}
 	for todoType, severity := range pending {
 		s.assignments[todoType] = severity
@@ -304,15 +299,17 @@ func (f *ignoreFlag) String() string {
 }
 
 func (f *ignoreFlag) Set(val string) error {
-	for _, typ := range strings.Split(val, ",") {
-		t := strings.TrimSpace(typ)
-		if t == "" {
+	rawTypes := strings.Split(val, ",")
+	normalizedTypes := todotype.NormalizeConfiguredTypes(rawTypes)
+	for i, normalizedType := range normalizedTypes {
+		rawType := strings.TrimSpace(rawTypes[i])
+		if normalizedType == "" {
 			return fmt.Errorf("invalid --ignore %q: type name is empty", val)
 		}
-		if strings.ContainsRune(t, '=') {
-			return fmt.Errorf("invalid --ignore %q: type name %q must not contain '='", val, t)
+		if strings.ContainsRune(rawType, '=') {
+			return fmt.Errorf("invalid --ignore %q: type name %q must not contain '='", val, rawType)
 		}
-		f.types = append(f.types, strings.ToUpper(t))
+		f.types = append(f.types, normalizedType)
 	}
 	return nil
 }

--- a/main_test.go
+++ b/main_test.go
@@ -900,6 +900,19 @@ func TestSeverityFlagParsing(t *testing.T) {
 		}
 	})
 
+	t.Run("duplicate types in one flag collapse case-insensitively", func(t *testing.T) {
+		s := newSeverityFlag()
+		if err := s.Set("warning=todo,TODO"); err != nil {
+			t.Fatalf("Set(warning=todo,TODO) unexpected error: %v", err)
+		}
+		if len(s.assignments) != 1 {
+			t.Fatalf("len(assignments) = %d, want 1", len(s.assignments))
+		}
+		if got := s.assignments["TODO"]; got != todotype.SeverityWarning {
+			t.Fatalf("assignments[TODO] = %q, want %q", got, todotype.SeverityWarning)
+		}
+	})
+
 	t.Run("whitespace trimming", func(t *testing.T) {
 		s := newSeverityFlag()
 		if err := s.Set("  warning  =  TODO  ,  HACK  "); err != nil {


### PR DESCRIPTION
## Summary

- add shared configured severity and TODO marker normalization helpers in `internal/todotype`
- reuse the shared helpers in CLI flag parsing and YAML config parsing without changing existing precedence or fail-fast behavior
- extend tests for shared parsing, case-insensitive duplicate handling, and ignore list normalization

Closes #96
