### PR TITLE
refactor(config): extract policy resolution from main

### DIFF
--- a/internal/policyresolve/policyresolve.go
+++ b/internal/policyresolve/policyresolve.go
@@ -1,0 +1,106 @@
+package policyresolve
+
+import (
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+
+	"github.com/Suree33/gh-pr-todo/internal/config"
+	"github.com/Suree33/gh-pr-todo/internal/todotype"
+)
+
+// Target describes which config source should be used for a run.
+type Target struct {
+	Repo      string
+	PR        string
+	UseRemote bool
+}
+
+// Options contains the inputs required to resolve a ready-to-use TODO policy.
+type Options struct {
+	Target        Target
+	CWD           string
+	UserConfigDir string
+	CLISeverities map[string]todotype.Severity
+	CLIIgnored    []string
+}
+
+// ResolveTarget determines whether config should be loaded locally or from a
+// remote repository, including PR URL normalization.
+func ResolveTarget(repo, pr string) Target {
+	if repo != "" {
+		return Target{Repo: repo, PR: pr, UseRemote: true}
+	}
+
+	parsed, err := url.Parse(pr)
+	if err != nil || parsed.Host == "" {
+		return Target{PR: pr}
+	}
+
+	parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	if len(parts) != 4 || parts[2] != "pull" || parts[0] == "" || parts[1] == "" || parts[3] == "" {
+		return Target{PR: pr}
+	}
+
+	repo = parts[0] + "/" + parts[1]
+	if parsed.Host != "github.com" {
+		repo = parsed.Host + "/" + repo
+	}
+
+	return Target{Repo: repo, PR: parts[3], UseRemote: true}
+}
+
+// Resolve loads configuration from the appropriate source and applies config
+// and CLI overrides on top of the default TODO policy.
+func Resolve(fetcher config.RemoteConfigFetcher, opts Options) (todotype.Policy, error) {
+	cfg, err := loadConfig(fetcher, opts)
+	if err != nil {
+		return todotype.Policy{}, err
+	}
+
+	policy := todotype.DefaultPolicy()
+	if len(cfg.Severities) > 0 {
+		policy = policy.WithSeverities(cfg.Severities)
+	}
+	if len(opts.CLISeverities) > 0 {
+		policy = policy.WithSeverities(opts.CLISeverities)
+	}
+
+	ignoredSet := make(map[string]bool, len(cfg.Ignored)+len(opts.CLIIgnored))
+	for todoType := range cfg.Ignored {
+		ignoredSet[todoType] = true
+	}
+	for _, todoType := range opts.CLIIgnored {
+		ignoredSet[strings.ToUpper(todoType)] = true
+	}
+	if len(ignoredSet) > 0 {
+		ignored := make([]string, 0, len(ignoredSet))
+		for todoType := range ignoredSet {
+			ignored = append(ignored, todoType)
+		}
+		sort.Strings(ignored)
+		policy = policy.WithIgnoredTypes(ignored)
+	}
+
+	return policy, nil
+}
+
+func loadConfig(fetcher config.RemoteConfigFetcher, opts Options) (config.Config, error) {
+	if opts.Target.UseRemote {
+		if fetcher == nil {
+			return config.Config{}, fmt.Errorf("remote config fetcher is required")
+		}
+
+		remoteCfg, err := config.LoadRemote(fetcher, opts.Target.Repo, opts.Target.PR)
+		if err != nil {
+			return config.Config{}, err
+		}
+		if remoteCfg.Found {
+			return remoteCfg, nil
+		}
+		return config.LoadGlobal(opts.UserConfigDir)
+	}
+
+	return config.LoadLocal(opts.CWD, opts.UserConfigDir)
+}

--- a/internal/policyresolve/policyresolve_test.go
+++ b/internal/policyresolve/policyresolve_test.go
@@ -1,0 +1,222 @@
+package policyresolve
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/Suree33/gh-pr-todo/internal/config"
+	"github.com/Suree33/gh-pr-todo/internal/todotype"
+	"github.com/Suree33/gh-pr-todo/pkg/types"
+)
+
+type fakeFetcher struct {
+	refs         config.RemoteConfigRefs
+	fileContents map[string]map[string][]byte
+}
+
+func (f *fakeFetcher) FetchRemoteConfigRefs(repo, pr string) (config.RemoteConfigRefs, error) {
+	return f.refs, nil
+}
+
+func (f *fakeFetcher) FetchFileAtRef(repo, path, ref string) ([]byte, bool, error) {
+	key := repo + ":" + ref
+	if contents, ok := f.fileContents[key]; ok {
+		if data, ok := contents[path]; ok {
+			return data, true, nil
+		}
+	}
+	return nil, false, nil
+}
+
+func TestResolveTarget(t *testing.T) {
+	tests := []struct {
+		name string
+		repo string
+		pr   string
+		want Target
+	}{
+		{
+			name: "explicit repo uses remote config",
+			repo: "owner/repo",
+			pr:   "123",
+			want: Target{Repo: "owner/repo", PR: "123", UseRemote: true},
+		},
+		{
+			name: "github PR URL uses remote config",
+			pr:   "https://github.com/owner/repo/pull/123",
+			want: Target{Repo: "owner/repo", PR: "123", UseRemote: true},
+		},
+		{
+			name: "host-qualified PR URL preserves host",
+			pr:   "https://github.example.com/owner/repo/pull/123",
+			want: Target{Repo: "github.example.com/owner/repo", PR: "123", UseRemote: true},
+		},
+		{
+			name: "non-PR URL stays local",
+			pr:   "https://github.com/owner/repo/issues/123",
+			want: Target{PR: "https://github.com/owner/repo/issues/123"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ResolveTarget(tt.repo, tt.pr); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("ResolveTarget() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolve(t *testing.T) {
+	t.Run("local config produces ready-to-use policy", func(t *testing.T) {
+		repoRoot := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(repoRoot, ".git"), 0755); err != nil {
+			t.Fatalf("MkdirAll() error: %v", err)
+		}
+		if err := os.MkdirAll(filepath.Join(repoRoot, ".github"), 0755); err != nil {
+			t.Fatalf("MkdirAll() error: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(repoRoot, ".github", "gh-pr-todo.yml"), []byte("severity:\n  error:\n    - TODO\nignore:\n  - note\n"), 0644); err != nil {
+			t.Fatalf("WriteFile() error: %v", err)
+		}
+
+		policy, err := Resolve(nil, Options{Target: ResolveTarget("", ""), CWD: repoRoot})
+		if err != nil {
+			t.Fatalf("Resolve() unexpected error: %v", err)
+		}
+		if got := policy.SeverityFor("TODO"); got != todotype.SeverityError {
+			t.Fatalf("SeverityFor(TODO) = %q, want %q", got, todotype.SeverityError)
+		}
+		if !policy.IsIgnored("NOTE") {
+			t.Fatal("NOTE should be ignored")
+		}
+		if got := policy.Types(); reflect.DeepEqual(got, []string{"BUG", "FIXME", "HACK", "TODO", "XXX"}) == false {
+			t.Fatalf("Types() = %v", got)
+		}
+	})
+
+	t.Run("remote config uses PR head precedence", func(t *testing.T) {
+		policy, err := Resolve(&fakeFetcher{
+			refs: config.RemoteConfigRefs{
+				DefaultBranchRef: "main",
+				DefaultRepo:      "owner/repo",
+				BaseBranchRef:    "release",
+				BaseRepo:         "owner/repo",
+				HeadRefOid:       "abc123",
+				HeadRepo:         "fork/repo",
+			},
+			fileContents: map[string]map[string][]byte{
+				"owner/repo:main": {
+					".github/gh-pr-todo.yml": []byte("severity:\n  warning:\n    - BUG\n"),
+				},
+				"owner/repo:release": {
+					".github/gh-pr-todo.yml": []byte("severity:\n  warning:\n    - FIXME\n"),
+				},
+				"fork/repo:abc123": {
+					".github/gh-pr-todo.yml": []byte("severity:\n  error:\n    - TODO\n"),
+				},
+			},
+		}, Options{Target: Target{Repo: "owner/repo", PR: "42", UseRemote: true}})
+		if err != nil {
+			t.Fatalf("Resolve() unexpected error: %v", err)
+		}
+		if got := policy.SeverityFor("TODO"); got != todotype.SeverityError {
+			t.Fatalf("SeverityFor(TODO) = %q, want %q", got, todotype.SeverityError)
+		}
+		if got := policy.SeverityFor("BUG"); got != todotype.SeverityWarning {
+			t.Fatalf("SeverityFor(BUG) = %q, want built-in %q after head replacement", got, todotype.SeverityWarning)
+		}
+		if got := policy.SeverityFor("FIXME"); got != todotype.SeverityWarning {
+			t.Fatalf("SeverityFor(FIXME) = %q, want built-in %q after head replacement", got, todotype.SeverityWarning)
+		}
+	})
+
+	t.Run("global config is used when no remote config exists", func(t *testing.T) {
+		userConfigDir := t.TempDir()
+		globalDir := filepath.Join(userConfigDir, "gh-pr-todo")
+		if err := os.MkdirAll(globalDir, 0755); err != nil {
+			t.Fatalf("MkdirAll() error: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(globalDir, "config.yml"), []byte("severity:\n  error:\n    - NOTE\n"), 0644); err != nil {
+			t.Fatalf("WriteFile() error: %v", err)
+		}
+
+		policy, err := Resolve(&fakeFetcher{
+			refs: config.RemoteConfigRefs{
+				DefaultBranchRef: "main",
+				DefaultRepo:      "owner/repo",
+			},
+			fileContents: map[string]map[string][]byte{},
+		}, Options{
+			Target:        Target{Repo: "owner/repo", PR: "42", UseRemote: true},
+			UserConfigDir: userConfigDir,
+		})
+		if err != nil {
+			t.Fatalf("Resolve() unexpected error: %v", err)
+		}
+		if got := policy.SeverityFor("NOTE"); got != todotype.SeverityError {
+			t.Fatalf("SeverityFor(NOTE) = %q, want %q", got, todotype.SeverityError)
+		}
+	})
+
+	t.Run("CLI severity overrides config severity", func(t *testing.T) {
+		repoRoot := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(repoRoot, ".git"), 0755); err != nil {
+			t.Fatalf("MkdirAll() error: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(repoRoot, ".gh-pr-todo.yml"), []byte("severity:\n  warning:\n    - TODO\n"), 0644); err != nil {
+			t.Fatalf("WriteFile() error: %v", err)
+		}
+
+		policy, err := Resolve(nil, Options{
+			Target: ResolveTarget("", ""),
+			CWD:    repoRoot,
+			CLISeverities: map[string]todotype.Severity{
+				"TODO": todotype.SeverityError,
+				"NOTE": todotype.SeverityWarning,
+			},
+		})
+		if err != nil {
+			t.Fatalf("Resolve() unexpected error: %v", err)
+		}
+		if got := policy.SeverityFor("TODO"); got != todotype.SeverityError {
+			t.Fatalf("SeverityFor(TODO) = %q, want %q", got, todotype.SeverityError)
+		}
+		if got := policy.SeverityFor("NOTE"); got != todotype.SeverityWarning {
+			t.Fatalf("SeverityFor(NOTE) = %q, want %q", got, todotype.SeverityWarning)
+		}
+	})
+
+	t.Run("ignore and severity settings are merged before building policy", func(t *testing.T) {
+		repoRoot := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(repoRoot, ".git"), 0755); err != nil {
+			t.Fatalf("MkdirAll() error: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(repoRoot, ".gh-pr-todo.yml"), []byte("severity:\n  error:\n    - NOTE\nignore:\n  - HACK\n"), 0644); err != nil {
+			t.Fatalf("WriteFile() error: %v", err)
+		}
+
+		policy, err := Resolve(nil, Options{
+			Target: ResolveTarget("", ""),
+			CWD:    repoRoot,
+			CLISeverities: map[string]todotype.Severity{
+				"HACK": todotype.SeverityError,
+			},
+			CLIIgnored: []string{"note"},
+		})
+		if err != nil {
+			t.Fatalf("Resolve() unexpected error: %v", err)
+		}
+		if !policy.IsIgnored("NOTE") || !policy.IsIgnored("HACK") {
+			t.Fatalf("expected NOTE and HACK to be ignored")
+		}
+		if got := policy.Types(); !reflect.DeepEqual(got, []string{"BUG", "FIXME", "TODO", "XXX"}) {
+			t.Fatalf("Types() = %v, want [BUG FIXME TODO XXX]", got)
+		}
+		if got := policy.CountCIFailing([]types.TODO{{Type: "NOTE"}, {Type: "HACK"}}); got != 0 {
+			t.Fatalf("CountCIFailing() = %d, want 0", got)
+		}
+	})
+}

--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -15,6 +14,7 @@ import (
 	"github.com/Suree33/gh-pr-todo/internal/config"
 	ghclient "github.com/Suree33/gh-pr-todo/internal/github"
 	"github.com/Suree33/gh-pr-todo/internal/output"
+	"github.com/Suree33/gh-pr-todo/internal/policyresolve"
 	"github.com/Suree33/gh-pr-todo/internal/todotype"
 	"github.com/Suree33/gh-pr-todo/pkg/types"
 	"github.com/briandowns/spinner"
@@ -130,79 +130,39 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Build policy with config and CLI overrides.
-	// Precedence: default < config < CLI.
-	// CLI ignore and severity have highest priority.
-	policy := todotype.DefaultPolicy()
-
 	userConfigDir := ""
 	if dir, err := os.UserConfigDir(); err == nil {
 		userConfigDir = dir
 	}
 
-	configRepo, configPR, useRemoteConfig := resolveConfigTarget(repo, pr)
-
-	var (
-		cfg config.Config
-		err error
-	)
-	if useRemoteConfig {
-		fetcher := ghclient.NewClient()
-		remoteCfg, err := config.LoadRemote(fetcher, configRepo, configPR)
-		if err != nil {
-			fmt.Fprintln(os.Stderr, "Remote config error:", err)
-			os.Exit(1)
-		}
-
-		if remoteCfg.Found {
-			cfg = remoteCfg
-		} else {
-			cfg, err = config.LoadGlobal(userConfigDir)
-			if err != nil {
-				fmt.Fprintln(os.Stderr, "Config error:", err)
-				os.Exit(1)
-			}
-		}
-	} else {
-		cwd, err := os.Getwd()
+	target := policyresolve.ResolveTarget(repo, pr)
+	cwd := ""
+	if !target.UseRemote {
+		var err error
+		cwd, err = os.Getwd()
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "Error getting current directory:", err)
 			os.Exit(1)
 		}
-		cfg, err = config.LoadLocal(cwd, userConfigDir)
-		if err != nil {
-			fmt.Fprintln(os.Stderr, "Config error:", err)
-			os.Exit(1)
-		}
-	}
-
-	// Apply severity overrides from config
-	if len(cfg.Severities) > 0 {
-		policy = policy.WithSeverities(cfg.Severities)
-	}
-
-	// Apply CLI severity overrides (highest priority)
-	if len(sevFlag.assignments) > 0 {
-		policy = policy.WithSeverities(sevFlag.assignments)
-	}
-
-	// Collect all ignored types from config and CLI, then apply together
-	ignoredSet := make(map[string]bool)
-	for t := range cfg.Ignored {
-		ignoredSet[t] = true
-	}
-	for _, t := range ignFlag.types {
-		ignoredSet[t] = true
-	}
-	if len(ignoredSet) > 0 {
-		ignored := make([]string, 0, len(ignoredSet))
-		for t := range ignoredSet {
-			ignored = append(ignored, t)
-		}
-		policy = policy.WithIgnoredTypes(ignored)
 	}
 
 	fetcher := ghclient.NewClient()
+	policy, err := policyresolve.Resolve(fetcher, policyresolve.Options{
+		Target:        target,
+		CWD:           cwd,
+		UserConfigDir: userConfigDir,
+		CLISeverities: sevFlag.assignments,
+		CLIIgnored:    ignFlag.types,
+	})
+	if err != nil {
+		if target.UseRemote {
+			fmt.Fprintln(os.Stderr, "Remote config error:", err)
+		} else {
+			fmt.Fprintln(os.Stderr, "Config error:", err)
+		}
+		os.Exit(1)
+	}
+
 	gha := isGitHubActions()
 	var result runResult
 	switch {
@@ -350,25 +310,6 @@ func isGitHubActions() bool {
 	v := strings.TrimSpace(os.Getenv("GITHUB_ACTIONS"))
 	ok, err := strconv.ParseBool(v)
 	return err == nil && ok
-}
-
-func resolveConfigTarget(repo, pr string) (string, string, bool) {
-	if repo != "" {
-		return repo, pr, true
-	}
-	parsed, err := url.Parse(pr)
-	if err != nil || parsed.Host == "" {
-		return "", pr, false
-	}
-	parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
-	if len(parts) != 4 || parts[2] != "pull" || parts[0] == "" || parts[1] == "" || parts[3] == "" {
-		return "", pr, false
-	}
-	repo = parts[0] + "/" + parts[1]
-	if parsed.Host != "github.com" {
-		repo = parsed.Host + "/" + repo
-	}
-	return repo, parts[3], true
 }
 
 func printUsage() {

--- a/main_test.go
+++ b/main_test.go
@@ -675,36 +675,6 @@ func TestRunFunctionsReturnZeroOnError(t *testing.T) {
 	})
 }
 
-func TestResolveConfigTarget(t *testing.T) {
-	t.Run("explicit repo uses remote config", func(t *testing.T) {
-		repo, pr, remote := resolveConfigTarget("owner/repo", "123")
-		if !remote || repo != "owner/repo" || pr != "123" {
-			t.Fatalf("resolveConfigTarget() = (%q, %q, %v)", repo, pr, remote)
-		}
-	})
-
-	t.Run("github PR URL uses remote config", func(t *testing.T) {
-		repo, pr, remote := resolveConfigTarget("", "https://github.com/owner/repo/pull/123")
-		if !remote || repo != "owner/repo" || pr != "123" {
-			t.Fatalf("resolveConfigTarget() = (%q, %q, %v)", repo, pr, remote)
-		}
-	})
-
-	t.Run("host-qualified PR URL preserves host", func(t *testing.T) {
-		repo, pr, remote := resolveConfigTarget("", "https://github.example.com/owner/repo/pull/123")
-		if !remote || repo != "github.example.com/owner/repo" || pr != "123" {
-			t.Fatalf("resolveConfigTarget() = (%q, %q, %v)", repo, pr, remote)
-		}
-	})
-
-	t.Run("non-PR URL stays local", func(t *testing.T) {
-		repo, pr, remote := resolveConfigTarget("", "https://github.com/owner/repo/issues/123")
-		if remote || repo != "" || pr != "https://github.com/owner/repo/issues/123" {
-			t.Fatalf("resolveConfigTarget() = (%q, %q, %v)", repo, pr, remote)
-		}
-	})
-}
-
 func TestPrintUsage(t *testing.T) {
 	originalCommandLine := pflag.CommandLine
 	pflag.CommandLine = pflag.NewFlagSet("gh pr-todo", pflag.ContinueOnError)


### PR DESCRIPTION
## Summary

- extract local/remote config and policy resolution into a focused `internal/policyresolve` package
- preserve existing config source precedence, including PR head remote config precedence and global fallback behavior
- add resolver tests for local config, remote config, global fallback, CLI override precedence, and ignore/severity interactions

Closes #95
