### PR TITLE
fix(cli): remove unused config import

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Suree33/gh-pr-todo/internal/config"
 	ghclient "github.com/Suree33/gh-pr-todo/internal/github"
 	"github.com/Suree33/gh-pr-todo/internal/initcmd"
 	"github.com/Suree33/gh-pr-todo/internal/output"


### PR DESCRIPTION
## Summary

- remove the unused `internal/config` import left in `main.go`
- restore `go test ./...` and `golangci-lint run` on `main`
- fix the failing CI typecheck introduced after the init refactor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused internal import to optimize code dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->